### PR TITLE
Fix for the nuget not getting restored on Client platforms. 

### DIFF
--- a/Microsoft.HealthVault.Client.Core/Microsoft.HealthVault.Client.Core.csproj
+++ b/Microsoft.HealthVault.Client.Core/Microsoft.HealthVault.Client.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grace" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.HealthVault\Microsoft.HealthVault.csproj" />

--- a/Microsoft.HealthVault.Client.nuspec
+++ b/Microsoft.HealthVault.Client.nuspec
@@ -18,18 +18,18 @@
       <group targetFramework="netstandard1.4">
       	<dependency id="Microsoft.HealthVault" version="(1.0,)" />
         <dependency id="Grace" version="6.0.1" />
-        <dependency id="Newtonsoft.Json" version="10.0.2" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
       </group>
       <group targetFramework="MonoAndroid">
       	<dependency id="Microsoft.HealthVault" version="(1.0,)" />
         <dependency id="Grace" version="6.0.1" />
-        <dependency id="Newtonsoft.Json" version="10.0.2" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="modernhttpclient" version="2.4.2" />
       </group>
       <group targetFramework="uap">
       	<dependency id="Microsoft.HealthVault" version="(1.0,)" />
         <dependency id="Grace" version="6.0.1" />
-        <dependency id="Newtonsoft.Json" version="10.0.2" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="5.2.2" />
         <dependency id="System.Diagnostics.TraceSource" version="4.3.0" />
         <dependency id="System.Net.Http" version="4.3.0" />
@@ -39,7 +39,7 @@
       <group targetFramework="Xamarin.iOS10">
       	<dependency id="Microsoft.HealthVault" version="(1.0,)" />
         <dependency id="Grace" version="6.0.1" />
-        <dependency id="Newtonsoft.Json" version="10.0.2" />
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
         <dependency id="modernhttpclient" version="2.4.2" />
       </group>
     </dependencies>

--- a/Microsoft.HealthVault.RestApi/Microsoft.HealthVault.RestApi.csproj
+++ b/Microsoft.HealthVault.RestApi/Microsoft.HealthVault.RestApi.csproj
@@ -7,7 +7,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.6" />
-    <PackageReference Include="newtonsoft.json" Version="10.0.2" />
+    <PackageReference Include="newtonsoft.json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.HealthVault.Web/Microsoft.HealthVault.Web.csproj
+++ b/Microsoft.HealthVault.Web/Microsoft.HealthVault.Web.csproj
@@ -43,8 +43,8 @@
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/Microsoft.HealthVault.Web/packages.config
+++ b/Microsoft.HealthVault.Web/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
   <package id="System.Net.Http" version="4.1.1" targetFramework="net461" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />

--- a/Microsoft.HealthVault.nuspec
+++ b/Microsoft.HealthVault.nuspec
@@ -17,8 +17,14 @@
     <dependencies>
       <group targetFramework="netstandard1.4">
         <dependency id="Grace" version="6.0.1" />
-        <dependency id="Microsoft.Rest.ClientRuntime" version="2.3.6" />
-        <dependency id="Newtonsoft.Json" version="10.0.2" />
+        <!-- Fix for bug# 54673: NuGet Package no longer installs on Visual Studio for Mac Preview -->
+        <!-- 
+            Nuget restore on client platforms (xamarin android and xamarin ios) is restoring a higher version of Microsoft.Rest.ClientRuntime
+            which require a higher .NET Core version than what xamarin supports. Fix is to restore the exact version of Microsoft.Rest.ClientRuntime - 2.3.6.
+            However, Microsoft.Rest.ClientRuntime version 2.3.6, restricts the Newtonsoft version to be 9.0.1 (greater than 9 and less than 10).
+        -->
+        <dependency id="Newtonsoft.Json" version="9.0.1" />
+        <dependency id="Microsoft.Rest.ClientRuntime" version="[2.3.6]" />
       </group>
     </dependencies>
   </metadata>

--- a/Microsoft.HealthVault/Microsoft.HealthVault.csproj
+++ b/Microsoft.HealthVault/Microsoft.HealthVault.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grace" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />

--- a/SandboxAndroid/SandboxAndroid.csproj
+++ b/SandboxAndroid/SandboxAndroid.csproj
@@ -52,8 +52,8 @@
     </Reference>
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.1\lib\netstandard1.3\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OkHttp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\modernhttpclient.2.4.2\lib\MonoAndroid\OkHttp.dll</HintPath>

--- a/SandboxAndroid/packages.config
+++ b/SandboxAndroid/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid70" />
   <package id="modernhttpclient" version="2.4.2" targetFramework="monoandroid70" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="monoandroid70" />
-  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="monoandroid70" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="monoandroid71" />
   <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid70" />
   <package id="System.Collections" version="4.3.0" targetFramework="monoandroid70" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid70" />

--- a/SandboxIos/SandboxIos.csproj
+++ b/SandboxIos/SandboxIos.csproj
@@ -189,8 +189,8 @@
       <HintPath>..\..\packages\Grace.5.1.0\lib\portable45-net45+win8+wp8+wpa81\Grace.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.1\lib\netstandard1.3\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />

--- a/SandboxIos/packages.config
+++ b/SandboxIos/packages.config
@@ -4,7 +4,7 @@
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="xamarinios10" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="xamarinios10" />
-  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="xamarinios10" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="xamarinios10" />
   <package id="System.AppContext" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinios10" />

--- a/SandboxWeb/SandboxWeb.csproj
+++ b/SandboxWeb/SandboxWeb.csproj
@@ -57,8 +57,8 @@
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/SandboxWeb/Web.config
+++ b/SandboxWeb/Web.config
@@ -48,7 +48,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
@@ -83,8 +83,8 @@
         is seems to not support the dll version that the web library require. Fix is to redirect to 4.0.0.0 version of System.Net.Http version. More information - https://github.com/dotnet/corefx/issues/9846
         -->
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.1" newVersion="4.0.0.0"/>
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.1" newVersion="4.1.0.1" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/SandboxWeb/packages.config
+++ b/SandboxWeb/packages.config
@@ -22,7 +22,7 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="Modernizr" version="2.6.2" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
   <package id="Respond" version="1.2.0" targetFramework="net452" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.3.0" targetFramework="net461" />
   <package id="System.Diagnostics.TraceSource" version="4.0.0" targetFramework="net461" />


### PR DESCRIPTION
Restore the exact version of Microsoft.Rest.ClientRuntime which is 2.3.6. This restricts the Newtonsoft version to be 9.01.