### PR TITLE
Fix integration tests

### DIFF
--- a/Microsoft.HealthVault.IntegrationTest/ThingTests.cs
+++ b/Microsoft.HealthVault.IntegrationTest/ThingTests.cs
@@ -39,12 +39,14 @@ namespace Microsoft.HealthVault.IntegrationTest
 
             var bloodPressure1 = new BloodPressure
             {
+                EffectiveDate = DateTime.Now,
                 Systolic = 110,
                 Diastolic = 90,
             };
 
             var bloodPressure2 = new BloodPressure
             {
+                EffectiveDate = DateTime.Now.AddHours(-1),
                 Systolic = 111,
                 Diastolic = 91,
             };

--- a/Microsoft.HealthVault.IntegrationTest/WeightTests.cs
+++ b/Microsoft.HealthVault.IntegrationTest/WeightTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.HealthVault.IntegrationTest
 
             List<Weight> weightList = new List<Weight>();
             weightList.Add(new Weight(
-                new HealthServiceDateTime(DateTime.Now),
+                new HealthServiceDateTime(DateTime.Now.AddHours(-1)),
                 new WeightValue(81, new DisplayValue(81, "KG", "kg"))));
 
             weightList.Add(new Weight(


### PR DESCRIPTION
Gave things different effective dates so the order they come back in is predictable. This make the tests more reliable.