### PR TITLE
Applying version to built DLLs

### DIFF
--- a/Microsoft.HealthVault.Client.Android/Microsoft.HealthVault.Client.Android.csproj
+++ b/Microsoft.HealthVault.Client.Android/Microsoft.HealthVault.Client.Android.csproj
@@ -59,6 +59,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedVersionInfo.cs">
+      <Link>Properties\SharedVersionInfo.cs</Link>
+    </Compile>
     <Compile Include="AndroidBrowserAuthBroker.cs" />
     <Compile Include="AndroidMessageHandlerFactory.cs" />
     <Compile Include="AndroidHealthVaultConnectionFactory.cs" />

--- a/Microsoft.HealthVault.Client.Android/Properties/AssemblyInfo.cs
+++ b/Microsoft.HealthVault.Client.Android/Properties/AssemblyInfo.cs
@@ -6,23 +6,5 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.HealthVault.Client")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Microsoft.HealthVault.Client")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: ComVisible(false)]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Microsoft.HealthVault.Client.Bait/Microsoft.HealthVault.Client.Bait.csproj
+++ b/Microsoft.HealthVault.Client.Bait/Microsoft.HealthVault.Client.Bait.csproj
@@ -1,18 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NetStandard.Common.targets))\NetStandard.Common.targets" />
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>full</DebugType>
-    <Company>Microsoft</Company>
     <Description>Microsoft HealthVault Bait SDK Assembly</Description>
-    <Copyright>Copyright © 2017</Copyright>
-    <Authors>DDX</Authors>
     <AssemblyName>Microsoft.HealthVault.Client</AssemblyName>
     <RootNamespace>Microsoft.HealthVault.Client</RootNamespace>
-    <AssemblyVersion>1.0.0.1</AssemblyVersion>
-    <FileVersion>1.0.0.1</FileVersion>
     <DocumentationFile>bin\$(Configuration)\netstandard1.4\Microsoft.HealthVault.Client.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.HealthVault.Client.Core/Microsoft.HealthVault.Client.Core.csproj
+++ b/Microsoft.HealthVault.Client.Core/Microsoft.HealthVault.Client.Core.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NetStandard.Common.targets))\NetStandard.Common.targets" />
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>full</DebugType>
-    <Company>Microsoft</Company>
     <Description>Microsoft HealthVault Client Core SDK Assembly</Description>
-    <Copyright>Copyright © 2017</Copyright>
-    <Authors>DDX</Authors>
-    <AssemblyVersion>1.0.0.1</AssemblyVersion>
-    <FileVersion>1.0.0.1</FileVersion>
     <DocumentationFile>bin\$(Configuration)\netstandard1.4\Microsoft.HealthVault.Client.Core.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.HealthVault.Client.Ios/Microsoft.HealthVault.Client.Ios.csproj
+++ b/Microsoft.HealthVault.Client.Ios/Microsoft.HealthVault.Client.Ios.csproj
@@ -51,6 +51,9 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedVersionInfo.cs">
+      <Link>Properties\SharedVersionInfo.cs</Link>
+    </Compile>
     <Compile Include="IosBrowserAuthBroker.cs" />
     <Compile Include="IosHealthVaultConnectionFactory.cs" />
     <Compile Include="IosClientIoc.cs" />

--- a/Microsoft.HealthVault.Client.Ios/Properties/AssemblyInfo.cs
+++ b/Microsoft.HealthVault.Client.Ios/Properties/AssemblyInfo.cs
@@ -7,30 +7,8 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.HealthVault.Client.Ios")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Microsoft.HealthVault.Client.Ios")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("426e8137-0fd9-43b9-a5e6-4a0d49c90a6f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Microsoft.HealthVault.Client.Uwp/Microsoft.HealthVault.Client.Uwp.csproj
+++ b/Microsoft.HealthVault.Client.Uwp/Microsoft.HealthVault.Client.Uwp.csproj
@@ -112,6 +112,9 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedVersionInfo.cs">
+      <Link>Properties\SharedVersionInfo.cs</Link>
+    </Compile>
     <Compile Include="DispatcherUtilities.cs" />
     <Compile Include="UwpBrowserAuthBroker.cs" />
     <Compile Include="UwpHealthVaultConnectionFactory.cs" />

--- a/Microsoft.HealthVault.Client.Uwp/Properties/AssemblyInfo.cs
+++ b/Microsoft.HealthVault.Client.Uwp/Properties/AssemblyInfo.cs
@@ -6,23 +6,5 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.HealthVault.Client")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Microsoft.HealthVault.Client")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: ComVisible(false)]

--- a/Microsoft.HealthVault.RestApi/Microsoft.HealthVault.RestApi.csproj
+++ b/Microsoft.HealthVault.RestApi/Microsoft.HealthVault.RestApi.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NetStandard.Common.targets))\NetStandard.Common.targets" />
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
 	<DocumentationFile>bin\$(Configuration)\netstandard1.4\Microsoft.HealthVault.RestApi.xml</DocumentationFile>

--- a/Microsoft.HealthVault.Web/Microsoft.HealthVault.Web.csproj
+++ b/Microsoft.HealthVault.Web/Microsoft.HealthVault.Web.csproj
@@ -95,6 +95,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedVersionInfo.cs">
+      <Link>Properties\SharedVersionInfo.cs</Link>
+    </Compile>
     <Compile Include="Attributes\SignOutAttribute.cs" />
     <Compile Include="AuthenticationModule.cs" />
     <Compile Include="Controllers\HealthVaultActionRedirectController.cs" />

--- a/Microsoft.HealthVault.Web/Properties/AssemblyInfo.cs
+++ b/Microsoft.HealthVault.Web/Properties/AssemblyInfo.cs
@@ -7,30 +7,8 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.HealthVault.Web")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Microsoft.HealthVault.Web")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7a84f34e-2cb2-49c8-b374-f6fddb24ba6c")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Microsoft.HealthVault/Microsoft.HealthVault.csproj
+++ b/Microsoft.HealthVault/Microsoft.HealthVault.csproj
@@ -1,16 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), NetStandard.Common.targets))\NetStandard.Common.targets" />
   <PropertyGroup>
     <TargetFramework>netstandard1.4</TargetFramework>
     <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>full</DebugType>
-    <Company>Microsoft</Company>
     <Description>Microsoft HealthVault SDK Assembly</Description>
-    <Copyright>Copyright ©  2017</Copyright>
-    <Authors>DDX</Authors>
-    <AssemblyVersion>1.0.0.1</AssemblyVersion>
-    <FileVersion>1.0.0.1</FileVersion>
     <DocumentationFile>bin\$(Configuration)\netstandard1.4\Microsoft.HealthVault.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>

--- a/NetStandard.Common.targets
+++ b/NetStandard.Common.targets
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  Defines default settings for .NET Standard PCL projects
+  
+  This targets file must be included before properties and item groups have been defined
+  (typically, the first import in a project file).
+-->
+
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Company>Microsoft Corporation</Company>
+    <Copyright>Copyright © Microsoft Corporation</Copyright>
+    <Authors>DDX</Authors>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+  </PropertyGroup>
+</Project>

--- a/SharedVersionInfo.cs
+++ b/SharedVersionInfo.cs
@@ -15,13 +15,12 @@ using System.Runtime.InteropServices;
 #endif
 
 [assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]
-[assembly: AssemblyProduct("Microsoft HealthVault (R)")]
+[assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]
+[assembly: AssemblyProduct("Microsoft HealthVault ®")]
 [assembly: CLSCompliant(false)]
 [assembly: ComVisible(false)]
 
-// NOTE: Always leave these values at 1.0.0.0 and 1.0.1.1 as the build process does a string replace with the actual build value.
 // Assembly version is set from build process in form major.minor.0.0.
 // Assembly file version will represent the assembly version with the same major and minor values.
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.1.1")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
Refactored some common properties for .NET Standard projects to NetStandard.Common.targets, including version.
Updated assembly version script to update this file, and changed other projects to use SharedVersionInfo.cs so it picks up the new version that the script writes to it.
Also updated script to no longer require the versions to be a specific value in order to do the replacement.