### PR TITLE
Removed System.Security.Cryptography.Cng dependency

### DIFF
--- a/Microsoft.HealthVault.nuspec
+++ b/Microsoft.HealthVault.nuspec
@@ -27,7 +27,6 @@
         <dependency id="System.Xml.XPath" version="4.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Diagnostics.TraceSource" version="4.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Xml.XDocument" version="4.3.0" exclude="Build,Analyzers" />
-        <dependency id="System.Security.Cryptography.Cng" version="4.3.0" exclude="Build,Analyzers" />
         <dependency id="System.Xml.ReaderWriter" version="4.3.0" exclude="Build,Analyzers" />
         <dependency id="System.Runtime.Serialization.Formatters" version="4.3.0" exclude="Build,Analyzers" />
         <dependency id="NETStandard.Library" version="1.6.1" exclude="Build,Analyzers" />


### PR DESCRIPTION
Was incompatible with the Android and iOS targets. Should be OK since it was working before this dependency was added.