### PR TITLE
Enabled multi-query requests on ThingClient

### DIFF
--- a/Microsoft.HealthVault.IntegrationTest/ThingTests.cs
+++ b/Microsoft.HealthVault.IntegrationTest/ThingTests.cs
@@ -86,10 +86,7 @@ namespace Microsoft.HealthVault.IntegrationTest
                 });
 
             var query = CreateMultiThingQuery();
-            var items = await thingClient.GetThingsAsync(record.Id, query);
-
-            Assert.AreEqual(1, items.Count);
-            ThingCollection thingCollection = items.First();
+            ThingCollection thingCollection = await thingClient.GetThingsAsync(record.Id, query);
 
             Assert.AreEqual(10, thingCollection.Count);
 
@@ -105,20 +102,59 @@ namespace Microsoft.HealthVault.IntegrationTest
             Assert.AreEqual(bloodPressure1.Systolic, returnedBloodPressures[0].Systolic);
         }
 
+        [TestMethod]
+        public async Task MultipleQueries()
+        {
+            IHealthVaultSodaConnection connection = HealthVaultConnectionFactory.Current.GetOrCreateSodaConnection(Constants.Configuration);
+            IThingClient thingClient = connection.CreateThingClient();
+            PersonInfo personInfo = await connection.GetPersonInfoAsync();
+            HealthRecordInfo record = personInfo.SelectedRecord;
+
+            await DeletePreviousThings(thingClient, record);
+
+            var bloodGlucose = new BloodGlucose(
+                new HealthServiceDateTime(DateTime.Now),
+                new BloodGlucoseMeasurement(
+                    4.2,
+                    new DisplayValue(4.2, "mmol/L", "mmol-per-l")),
+                new CodableValue("Whole blood", "wb", new VocabularyKey("glucose-measurement-type", "wc", "1")));
+
+            var weight = new Weight(
+                new HealthServiceDateTime(DateTime.Now),
+                new WeightValue(81, new DisplayValue(81, "KG", "kg")));
+
+            await thingClient.CreateNewThingsAsync(
+                record.Id,
+                new List<IThing>
+                {
+                    bloodGlucose,
+                    weight,
+                });
+
+            var resultSet = await thingClient.GetThingsAsync(record.Id, new[] { new ThingQuery(BloodGlucose.TypeId), new ThingQuery(Weight.TypeId) });
+            Assert.AreEqual(2, resultSet.Count);
+            var resultList = resultSet.ToList();
+
+            ThingCollection glucoseCollection = resultList[0];
+            var returnedBloodGlucose = (BloodGlucose)glucoseCollection.First();
+            Assert.AreEqual(bloodGlucose.Value.Value, returnedBloodGlucose.Value.Value);
+
+            ThingCollection weightCollection = resultList[1];
+            var returnedWeight = (Weight)weightCollection.First();
+            Assert.AreEqual(weight.Value.Kilograms, returnedWeight.Value.Kilograms);
+        }
+
         private static async Task DeletePreviousThings(IThingClient thingClient, HealthRecordInfo record)
         {
             var query = CreateMultiThingQuery();
 
-            var items = await thingClient.GetThingsAsync(record.Id, query);
+            var thingCollection = await thingClient.GetThingsAsync(record.Id, query);
 
             var thingsToDelete = new List<IThing>();
 
-            foreach (ThingCollection thingCollection in items)
+            foreach (IThing thing in thingCollection)
             {
-                foreach (IThing thing in thingCollection)
-                {
-                    thingsToDelete.Add(thing);
-                }
+                thingsToDelete.Add(thing);
             }
 
             if (thingsToDelete.Count > 0)

--- a/Microsoft.HealthVault.UnitTest/Microsoft.HealthVault.UnitTest.csproj
+++ b/Microsoft.HealthVault.UnitTest/Microsoft.HealthVault.UnitTest.csproj
@@ -170,6 +170,9 @@
     <EmbeddedResource Include="Samples\GetServiceDefinitionResult.xml" />
     <EmbeddedResource Include="Samples\GetAuthorizedPeopleResult.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Samples\ThingsMultiQueryResult.xml" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/Microsoft.HealthVault.UnitTest/Samples/ThingsMultiQueryResult.xml
+++ b/Microsoft.HealthVault.UnitTest/Samples/ThingsMultiQueryResult.xml
@@ -1,0 +1,110 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<response>
+  <status>
+    <code>0</code>
+  </status>
+  <wc:info xmlns:wc="urn:com.microsoft.wc.methods.response.GetThings3">
+    <group>
+      <thing>
+        <thing-id version-stamp="9b379300-bb6f-4d46-8ff0-328a04513f30">295eda72-9b30-4811-82ab-33d34b979705</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-10T00:00:00</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>10</d>
+              </date>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>29</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2a0e1f1a-3a61-4446-8d28-4ffbe6c9350f">a1a6ab8a-7169-459b-98e1-9d6d880098b5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-09T11:00:44.759</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>9</d>
+              </date>
+              <time>
+                <h>11</h>
+                <m>0</m>
+                <s>44</s>
+                <f>759</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8ca1fe29-ee44-4187-9255-2cef77f965ee">09883e46-7bfd-4af4-9026-0b5b9fbd77a5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-03-23T12:39:48.107</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>3</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>39</m>
+                <s>48</s>
+                <f>107</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+    </group>
+    <group>
+      <thing>
+        <thing-id version-stamp="e4923f24-9413-4bc9-adb3-e269f65013d3">711627e2-7dab-4ce5-a5b2-5b601e235bb7</thing-id>
+        <type-id name="Weight">3d34d87e-7fc1-4153-800f-f56592cb0d17</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2014-10-26T00:00:00</eff-date>
+        <data-xml>
+          <weight>
+            <when>
+              <date>
+                <y>2014</y>
+                <m>10</m>
+                <d>26</d>
+              </date>
+            </when>
+            <value>
+              <kg>74.84274105165585</kg>
+              <display units="lbs" units-code="lb">165</display>
+            </value>
+          </weight>
+          <common />
+        </data-xml>
+      </thing>
+    </group>
+  </wc:info>
+</response>

--- a/Microsoft.HealthVault/Clients/IThingClient.cs
+++ b/Microsoft.HealthVault/Clients/IThingClient.cs
@@ -32,8 +32,16 @@ namespace Microsoft.HealthVault.Clients
         /// </summary>
         /// <param name="recordId">The health record's ID.</param>
         /// <param name="query">An instance of <see cref="ThingQuery"/>.  Use this query to identify parameters for the search.</param>
-        /// <returns>ICollection of ThingBase</returns>
-        Task<IReadOnlyCollection<ThingCollection>> GetThingsAsync(Guid recordId, ThingQuery query);
+        /// <returns>A collection of things returned from the query.</returns>
+        Task<ThingCollection> GetThingsAsync(Guid recordId, ThingQuery query);
+
+        /// <summary>
+        /// Gets a collection of Things that match a given query.
+        /// </summary>
+        /// <param name="recordId">The health record's ID.</param>
+        /// <param name="queries">A collection of <see cref="ThingQuery"/> objects.  Use these queries to identify parameters for the search.</param>
+        /// <returns>A group of results for the queries. Each <see cref="ThingCollection"/> corresponds to a <see cref="ThingQuery"/> passed in.</returns>
+        Task<IReadOnlyCollection<ThingCollection>> GetThingsAsync(Guid recordId, IEnumerable<ThingQuery> queries);
 
         /// <summary>
         /// Gets a collection of Things of the specific type.

--- a/Microsoft.HealthVault/Helpers/Validator.cs
+++ b/Microsoft.HealthVault/Helpers/Validator.cs
@@ -74,7 +74,7 @@ namespace Microsoft.HealthVault.Helpers
 
         public static void ThrowIfGuidEmpty(Guid argument, string argumentName)
         {
-            if (argument == null)
+            if (argument == Guid.Empty)
             {
                 throw new ArgumentException(Resources.GuidParameterEmpty, argumentName);
             }

--- a/Microsoft.HealthVault/Helpers/Validator.cs
+++ b/Microsoft.HealthVault/Helpers/Validator.cs
@@ -7,6 +7,7 @@
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Collections.Generic;
 using System.Xml;
 using System.Xml.XPath;
 using Microsoft.HealthVault.Exceptions;
@@ -55,11 +56,40 @@ namespace Microsoft.HealthVault.Helpers
             }
         }
 
+        public static void ThrowIfArgumentNull(object argument, string argumentName)
+        {
+            if (argument == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+        }
+
         public static void ThrowIfArgumentNull(object argument, string argumentName, string message)
         {
             if (argument == null)
             {
                 throw new ArgumentNullException(argumentName, message);
+            }
+        }
+
+        public static void ThrowIfGuidEmpty(Guid argument, string argumentName)
+        {
+            if (argument == null)
+            {
+                throw new ArgumentException(Resources.GuidParameterEmpty, argumentName);
+            }
+        }
+
+        public static void ThrowIfCollectionNullOrEmpty<T>(ICollection<T> argument, string argumentName)
+        {
+            if (argument == null)
+            {
+                throw new ArgumentNullException(argumentName);
+            }
+
+            if (argument.Count == 0)
+            {
+                throw new ArgumentException(Resources.CollectionEmpty, argumentName);
             }
         }
 

--- a/Microsoft.HealthVault/Resources.Designer.cs
+++ b/Microsoft.HealthVault/Resources.Designer.cs
@@ -1898,6 +1898,15 @@ namespace Microsoft.HealthVault {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Collection cannot be empty..
+        /// </summary>
+        internal static string CollectionEmpty {
+            get {
+                return ResourceManager.GetString("CollectionEmpty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value of the Content property cannot be null or empty..
         /// </summary>
         internal static string CommentContentMandatory {
@@ -4567,15 +4576,6 @@ namespace Microsoft.HealthVault {
         internal static string NameToStringFormat {
             get {
                 return ResourceManager.GetString("NameToStringFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The things must be specified when creating a new item..
-        /// </summary>
-        internal static string NewItemNullItem {
-            get {
-                return ResourceManager.GetString("NewItemNullItem", resourceCulture);
             }
         }
         

--- a/Microsoft.HealthVault/Resources.resx
+++ b/Microsoft.HealthVault/Resources.resx
@@ -291,9 +291,6 @@
   <data name="HealthRecordNotUpdated" xml:space="preserve">
     <value>The data for this property is not available until Refresh is called.</value>
   </data>
-  <data name="NewItemNullItem" xml:space="preserve">
-    <value>The things must be specified when creating a new item.</value>
-  </data>
   <data name="NewItemsNullItem" xml:space="preserve">
     <value>A valid enumeration of non-null things must be provided.</value>
   </data>
@@ -2294,5 +2291,8 @@
   </data>
   <data name="CannotCallAuthorizeAdditionalRecords" xml:space="preserve">
     <value>Cannot call authorize additional records. First authorization is not yet complete.</value>
+  </data>
+  <data name="CollectionEmpty" xml:space="preserve">
+    <value>Collection cannot be empty.</value>
   </data>
 </root>

--- a/Microsoft.HealthVault/Thing/ThingCollection.cs
+++ b/Microsoft.HealthVault/Thing/ThingCollection.cs
@@ -1072,8 +1072,7 @@ namespace Microsoft.HealthVault.Thing
                 }
             }
 
-            IReadOnlyCollection<ThingCollection> thingCollection = await GetPartialThingsAsync(partialThings).ConfigureAwait(false);
-            ThingCollection things = thingCollection.FirstOrDefault();
+            ThingCollection things = await GetPartialThingsAsync(partialThings).ConfigureAwait(false);
 
             bool atEndOfPartialThings = false;
             int newThingIndex = index;
@@ -1113,7 +1112,7 @@ namespace Microsoft.HealthVault.Thing
             }
         }
 
-        private async Task<IReadOnlyCollection<ThingCollection>> GetPartialThingsAsync(
+        private async Task<ThingCollection> GetPartialThingsAsync(
             IList<ThingKey> partialThings)
         {
             IThingClient thingClient = Connection.CreateThingClient();
@@ -1137,7 +1136,7 @@ namespace Microsoft.HealthVault.Thing
                 }
             }
 
-            IReadOnlyCollection<ThingCollection> results = await thingClient.GetThingsAsync(Record.Id, query).ConfigureAwait(false);
+            ThingCollection results = await thingClient.GetThingsAsync(Record.Id, query).ConfigureAwait(false);
 
             return results;
         }

--- a/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml
+++ b/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml
@@ -8,6 +8,7 @@
         <Button Clicked="Connect_OnClicked" Text="Connect" />
         <Button Clicked="SetBP_OnClicked" Text="Add BP" />
         <Button Clicked="GetBP_OnClicked" Text="Get BP" />
+        <Button Clicked="MultiQuery_OnClicked" Text="Get Things Multi-Query" />
         <Label x:Name="OutputLabel" />
     </StackLayout>
 </ContentPage>

--- a/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml.cs
+++ b/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.HealthVault.Clients;
 using Microsoft.HealthVault.Configuration;
 using Microsoft.HealthVault.ItemTypes;
 using Microsoft.HealthVault.Person;
+using Microsoft.HealthVault.Thing;
 using Xamarin.Forms;
 
 namespace SandboxXamarinForms
@@ -68,6 +69,22 @@ namespace SandboxXamarinForms
             {
                 OutputLabel.Text = firstBloodPressure.Systolic + "/" + firstBloodPressure.Diastolic;
             }
+        }
+
+        private async void MultiQuery_OnClicked(object sender, EventArgs e)
+        {
+            PersonInfo personInfo = await _connection.GetPersonInfoAsync();
+            var resultSet = await _thingClient.GetThingsAsync(
+                personInfo.SelectedRecord.Id, 
+                new List<ThingQuery>
+                {
+                    new ThingQuery(BloodPressure.TypeId),
+                    new ThingQuery(Weight.TypeId)
+                });
+
+            var resultList = resultSet.ToList();
+
+            OutputLabel.Text = $"There are {resultList[0].Count} blood pressure(s) and {resultList[1].Count} weight(s).";
         }
     }
 }


### PR DESCRIPTION
Split the existing method into a version that takes a single ThingQuery and returns a single ThingCollection and one that takes multiple ThingQueries and returns a collection of ThingCollections.

Updated and added more unit and integration tests.