### PR TITLE
Applied Jack's fix for ApproximateDateTime Equals

### DIFF
--- a/Microsoft.HealthVault.UnitTest/ItemTypes/ApproximateDateTimeTests.cs
+++ b/Microsoft.HealthVault.UnitTest/ItemTypes/ApproximateDateTimeTests.cs
@@ -1,3 +1,11 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// MIT License
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using Microsoft.HealthVault.ItemTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;

--- a/Microsoft.HealthVault.UnitTest/ItemTypes/ApproximateDateTimeTests.cs
+++ b/Microsoft.HealthVault.UnitTest/ItemTypes/ApproximateDateTimeTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.HealthVault.ItemTypes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Microsoft.HealthVault.UnitTest.ItemTypes
+{
+    [TestClass]
+    public class ApproximateDateTimeTests
+    {
+        [TestMethod]
+        public void TestEqualsWrongType()
+        {
+            ApproximateDateTime dateTime = new ApproximateDateTime();
+
+            Assert.IsFalse(dateTime.Equals(this), "The equals should return false.");
+        }
+
+        [TestMethod]
+        public void TestEqualsNull()
+        {
+            ApproximateDateTime dateTime = new ApproximateDateTime();
+
+            Assert.IsFalse(dateTime.Equals(null), "The equals should return false.");
+        }
+
+        [TestMethod]
+        public void TestEqualsSameDate()
+        {
+            ApproximateDate date = new ApproximateDate(2017);
+
+            ApproximateDateTime dateTime1 = new ApproximateDateTime(date);
+            ApproximateDateTime dateTime2 = new ApproximateDateTime(date);
+
+            Assert.IsTrue(dateTime1.Equals(dateTime2), "The equals should return true.");
+        }
+    }
+}

--- a/Microsoft.HealthVault.UnitTest/ItemTypes/ApproximateDateTimeTests.cs
+++ b/Microsoft.HealthVault.UnitTest/ItemTypes/ApproximateDateTimeTests.cs
@@ -6,6 +6,7 @@
 //
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using Microsoft.HealthVault.ItemTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -16,30 +17,57 @@ namespace Microsoft.HealthVault.UnitTest.ItemTypes
     public class ApproximateDateTimeTests
     {
         [TestMethod]
-        public void TestEqualsWrongType()
+        public void WhenWrongTypePassedToEquals_ThenFalseReturned()
         {
             ApproximateDateTime dateTime = new ApproximateDateTime();
 
-            Assert.IsFalse(dateTime.Equals(this), "The equals should return false.");
+            Assert.IsFalse(dateTime.Equals(this), "Equals should return false.");
         }
 
         [TestMethod]
-        public void TestEqualsNull()
+        public void WhenNullPassedToEquals_ThenFalseReturned()
         {
             ApproximateDateTime dateTime = new ApproximateDateTime();
 
-            Assert.IsFalse(dateTime.Equals(null), "The equals should return false.");
+            Assert.IsFalse(dateTime.Equals(null), "Equals should return false.");
         }
 
         [TestMethod]
-        public void TestEqualsSameDate()
+        public void WhenSameDatePassedToEquals_ThenTrueReturned()
         {
             ApproximateDate date = new ApproximateDate(2017);
 
             ApproximateDateTime dateTime1 = new ApproximateDateTime(date);
             ApproximateDateTime dateTime2 = new ApproximateDateTime(date);
 
-            Assert.IsTrue(dateTime1.Equals(dateTime2), "The equals should return true.");
+            Assert.IsTrue(dateTime1.Equals(dateTime2), "Equals should return true.");
+        }
+
+        [TestMethod]
+        public void WhenDifferentDatePassedToEquals_ThenFalseReturned()
+        {
+            ApproximateDateTime dateTime1 = new ApproximateDateTime(new DateTime(2017, 5, 18, 5, 28, 20, DateTimeKind.Utc));
+            ApproximateDateTime dateTime2 = new ApproximateDateTime(new DateTime(2017, 5, 18, 5, 27, 20, DateTimeKind.Utc));
+
+            Assert.IsFalse(dateTime1.Equals(dateTime2), "Equals should return false.");
+        }
+
+        [TestMethod]
+        public void WhenSameDateTimePassedToEquals_ThenTrueReturned()
+        {
+            ApproximateDateTime approximateDateTime = new ApproximateDateTime(new DateTime(2017, 5, 18, 5, 28, 20, DateTimeKind.Utc));
+            DateTime dateTime = new DateTime(2017, 5, 18, 5, 28, 20, DateTimeKind.Utc);
+
+            Assert.IsTrue(approximateDateTime.Equals(dateTime), "Equals should return true");
+        }
+
+        [TestMethod]
+        public void WhenDifferentDateTimePassedToEquals_ThenFalseReturned()
+        {
+            ApproximateDateTime approximateDateTime = new ApproximateDateTime(new DateTime(2017, 5, 18, 5, 28, 20, DateTimeKind.Utc));
+            DateTime dateTime = new DateTime(2017, 5, 18, 5, 27, 20, DateTimeKind.Utc);
+
+            Assert.IsFalse(approximateDateTime.Equals(dateTime), "Equals should return false");
         }
     }
 }

--- a/Microsoft.HealthVault.UnitTest/ItemTypes/HealthServiceDateTimeTests.cs
+++ b/Microsoft.HealthVault.UnitTest/ItemTypes/HealthServiceDateTimeTests.cs
@@ -6,6 +6,7 @@
 //
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+using System;
 using Microsoft.HealthVault.ItemTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
@@ -16,7 +17,7 @@ namespace Microsoft.HealthVault.UnitTest.ItemTypes
     public class HealthServiceDateTimeTests
     {
         [TestMethod]
-        public void TestEqualsWrongType()
+        public void WhenWrongTypePassedToEquals_ThenFalseReturned()
         {
             HealthServiceDateTime dateTime = new HealthServiceDateTime();
 
@@ -24,7 +25,7 @@ namespace Microsoft.HealthVault.UnitTest.ItemTypes
         }
 
         [TestMethod]
-        public void TestEqualsNull()
+        public void WhenNullPassedToEquals_ThenFalseReturned()
         {
             HealthServiceDateTime dateTime = new HealthServiceDateTime();
 
@@ -32,7 +33,7 @@ namespace Microsoft.HealthVault.UnitTest.ItemTypes
         }
 
         [TestMethod]
-        public void TestEqualsSameDate()
+        public void WhenSameDatePassedToEquals_ThenTrueReturned()
         {
             HealthServiceDate date = new HealthServiceDate(2017, 1, 12);
 
@@ -40,6 +41,33 @@ namespace Microsoft.HealthVault.UnitTest.ItemTypes
             HealthServiceDateTime dateTime2 = new HealthServiceDateTime(date);
 
             Assert.IsTrue(dateTime1.Equals(dateTime2), "The equals should return true.");
+        }
+
+        [TestMethod]
+        public void WhenDifferentDatePassedToEquals_ThenFalseReturned()
+        {
+            HealthServiceDateTime dateTime1 = new HealthServiceDateTime(new DateTime(2017, 5, 18, 5, 28, 20, DateTimeKind.Utc));
+            HealthServiceDateTime dateTime2 = new HealthServiceDateTime(new DateTime(2017, 5, 18, 5, 27, 20, DateTimeKind.Utc));
+
+            Assert.IsFalse(dateTime1.Equals(dateTime2), "Equals should return false.");
+        }
+
+        [TestMethod]
+        public void WhenSameDateTimePassedToEquals_ThenTrueReturned()
+        {
+            HealthServiceDateTime healthServiceDateTime = new HealthServiceDateTime(new DateTime(2017, 5, 18, 5, 28, 20, DateTimeKind.Utc));
+            DateTime dateTime = new DateTime(2017, 5, 18, 5, 28, 20, DateTimeKind.Utc);
+
+            Assert.IsTrue(healthServiceDateTime.Equals(dateTime), "Equals should return true");
+        }
+
+        [TestMethod]
+        public void WhenDifferentDateTimePassedToEquals_ThenFalseReturned()
+        {
+            HealthServiceDateTime healthServiceDateTime = new HealthServiceDateTime(new DateTime(2017, 5, 18, 5, 28, 20, DateTimeKind.Utc));
+            DateTime dateTime = new DateTime(2017, 5, 18, 5, 27, 20, DateTimeKind.Utc);
+
+            Assert.IsFalse(healthServiceDateTime.Equals(dateTime), "Equals should return false");
         }
     }
 }

--- a/Microsoft.HealthVault.UnitTest/ItemTypes/HealthServiceDateTimeTests.cs
+++ b/Microsoft.HealthVault.UnitTest/ItemTypes/HealthServiceDateTimeTests.cs
@@ -1,3 +1,11 @@
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// MIT License
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 using Microsoft.HealthVault.ItemTypes;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;

--- a/Microsoft.HealthVault.UnitTest/ItemTypes/HealthServiceDateTimeTests.cs
+++ b/Microsoft.HealthVault.UnitTest/ItemTypes/HealthServiceDateTimeTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.HealthVault.ItemTypes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+
+namespace Microsoft.HealthVault.UnitTest.ItemTypes
+{
+    [TestClass]
+    public class HealthServiceDateTimeTests
+    {
+        [TestMethod]
+        public void TestEqualsWrongType()
+        {
+            HealthServiceDateTime dateTime = new HealthServiceDateTime();
+
+            Assert.IsFalse(dateTime.Equals(this), "The equals should return false.");
+        }
+
+        [TestMethod]
+        public void TestEqualsNull()
+        {
+            HealthServiceDateTime dateTime = new HealthServiceDateTime();
+
+            Assert.IsFalse(dateTime.Equals(null), "The equals should return false.");
+        }
+
+        [TestMethod]
+        public void TestEqualsSameDate()
+        {
+            HealthServiceDate date = new HealthServiceDate(2017, 1, 12);
+
+            HealthServiceDateTime dateTime1 = new HealthServiceDateTime(date);
+            HealthServiceDateTime dateTime2 = new HealthServiceDateTime(date);
+
+            Assert.IsTrue(dateTime1.Equals(dateTime2), "The equals should return true.");
+        }
+    }
+}

--- a/Microsoft.HealthVault.UnitTest/Microsoft.HealthVault.UnitTest.csproj
+++ b/Microsoft.HealthVault.UnitTest/Microsoft.HealthVault.UnitTest.csproj
@@ -123,6 +123,8 @@
     <Compile Include="Connection\HttpClientFactoryTests.cs" />
     <Compile Include="HealthVaultConnectionFactoryInternalTests.cs" />
     <Compile Include="HealthVaultSodaConnectionTests.cs" />
+    <Compile Include="ItemTypes\ApproximateDateTimeTests.cs" />
+    <Compile Include="ItemTypes\HealthServiceDateTimeTests.cs" />
     <Compile Include="LocalObjectStoreTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rest\GivenARestRequest.cs" />

--- a/Microsoft.HealthVault/ItemTypes/ApproximateDateTime.cs
+++ b/Microsoft.HealthVault/ItemTypes/ApproximateDateTime.cs
@@ -542,6 +542,11 @@ namespace Microsoft.HealthVault.ItemTypes
         ///
         public override bool Equals(object obj)
         {
+            if (obj?.GetType() != this.GetType())
+            {
+                return false;
+            }
+
             return CompareTo(obj) == 0;
         }
 

--- a/Microsoft.HealthVault/ItemTypes/ApproximateDateTime.cs
+++ b/Microsoft.HealthVault/ItemTypes/ApproximateDateTime.cs
@@ -542,7 +542,8 @@ namespace Microsoft.HealthVault.ItemTypes
         ///
         public override bool Equals(object obj)
         {
-            if (obj?.GetType() != this.GetType())
+            Type objectType = obj?.GetType();
+            if (objectType != this.GetType() && objectType != typeof(DateTime))
             {
                 return false;
             }

--- a/Microsoft.HealthVault/ItemTypes/ApproximateTime.cs
+++ b/Microsoft.HealthVault/ItemTypes/ApproximateTime.cs
@@ -452,6 +452,55 @@ namespace Microsoft.HealthVault.ItemTypes
         }
 
         /// <summary>
+        /// Compares the specified object to this <see cref="DateTime"/> object.
+        /// </summary>
+        ///
+        /// <param name="other">
+        /// The time to be compared.
+        /// </param>
+        ///
+        /// <returns>
+        /// A 32-bit signed integer that indicates the relative order of the
+        /// objects being compared. If the result is less than zero, the
+        /// instance is less than <paramref name="other"/>. If the result is zero,
+        /// the instance is equal to <paramref name="other"/>. If the result is
+        /// greater than zero, the instance is greater than
+        /// <paramref name="other"/>.
+        /// </returns>
+        public int CompareTo(DateTime other)
+        {
+            if (Hour > other.Hour)
+            {
+                return 1;
+            }
+
+            if (Hour < other.Hour)
+            {
+                return -1;
+            }
+
+            if (Minute > other.Minute)
+            {
+                return 1;
+            }
+
+            if (Minute < other.Minute)
+            {
+                return -1;
+            }
+
+            int result = ApproximateTime.CompareOptional(Second, other.Second);
+
+            if (result != 0)
+            {
+                return result;
+            }
+
+            return ApproximateTime.CompareOptional(Millisecond, other.Millisecond);
+        }
+
+
+        /// <summary>
         /// Compares the specified object to this ApproximateDate object.
         /// </summary>
         ///

--- a/Microsoft.HealthVault/ItemTypes/HealthServiceDateTime.cs
+++ b/Microsoft.HealthVault/ItemTypes/HealthServiceDateTime.cs
@@ -141,11 +141,8 @@ namespace Microsoft.HealthVault.ItemTypes
                 new ApproximateTime(
                     dateTime.Hour,
                     dateTime.Minute,
-                    dateTime.Second);
-            if (dateTime.Millisecond != 0)
-            {
-                _time.Millisecond = dateTime.Millisecond;
-            }
+                    dateTime.Second,
+                    dateTime.Millisecond);
         }
 
         /// <summary>
@@ -511,7 +508,7 @@ namespace Microsoft.HealthVault.ItemTypes
                 return -1;
             }
 
-            return 0;
+            return Time.CompareTo(other);
         }
 
         #endregion IComparable
@@ -540,7 +537,8 @@ namespace Microsoft.HealthVault.ItemTypes
         ///
         public override bool Equals(object obj)
         {
-            if (obj?.GetType() != this.GetType())
+            Type objectType = obj?.GetType();
+            if (objectType != this.GetType() && objectType != typeof(DateTime))
             {
                 return false;
             }

--- a/Microsoft.HealthVault/ItemTypes/HealthServiceDateTime.cs
+++ b/Microsoft.HealthVault/ItemTypes/HealthServiceDateTime.cs
@@ -540,6 +540,11 @@ namespace Microsoft.HealthVault.ItemTypes
         ///
         public override bool Equals(object obj)
         {
+            if (obj?.GetType() != this.GetType())
+            {
+                return false;
+            }
+
             return CompareTo(obj) == 0;
         }
 


### PR DESCRIPTION
 It checks the type to make sure it doesn't throw an exception from the method.