### PR TITLE
Fixed multi-part requests on ThingClient

### DIFF
--- a/Microsoft.HealthVault.UnitTest/Clients/ThingDeserializerTests.cs
+++ b/Microsoft.HealthVault.UnitTest/Clients/ThingDeserializerTests.cs
@@ -20,7 +20,7 @@ using NSubstitute;
 namespace Microsoft.HealthVault.UnitTest.Clients
 {
     [TestClass]
-    public class ThingDesrializerTests
+    public class ThingDeserializerTests
     {
         private ThingDeserializer _thingDeserializer;
         private HealthRecordAccessor _healthRecordAccessor;

--- a/Microsoft.HealthVault.UnitTest/Microsoft.HealthVault.UnitTest.csproj
+++ b/Microsoft.HealthVault.UnitTest/Microsoft.HealthVault.UnitTest.csproj
@@ -117,7 +117,7 @@
     <Compile Include="Clients\PersonClientTests.cs" />
     <Compile Include="Clients\ThingClientTests.cs" />
     <Compile Include="Clients\PlatformClientTests.cs" />
-    <Compile Include="Clients\ThingDesrializerTests.cs" />
+    <Compile Include="Clients\ThingDeserializerTests.cs" />
     <Compile Include="Clients\VocabularyClientTests.cs" />
     <Compile Include="CloudRequestTests\TestHealthWebRequestClient.cs" />
     <Compile Include="Connection\HttpClientFactoryTests.cs" />
@@ -174,6 +174,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Samples\ThingsMultiQueryResult.xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Samples\ThingsPagedResult1.xml" />
+    <EmbeddedResource Include="Samples\ThingsPagedResult2.xml" />
+    <EmbeddedResource Include="Samples\ThingsPagedResult3.xml" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/Microsoft.HealthVault.UnitTest/Samples/ThingsPagedResult1.xml
+++ b/Microsoft.HealthVault.UnitTest/Samples/ThingsPagedResult1.xml
@@ -1,0 +1,7805 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<response>
+  <status>
+    <code>0</code>
+  </status>
+  <wc:info xmlns:wc="urn:com.microsoft.wc.methods.response.GetThings3">
+    <group>
+      <thing>
+        <thing-id version-stamp="29c3ed8e-1ef5-410c-bdd9-0b6930274aeb">6e4f28b1-a8d4-4374-8f1e-153fd49a6512</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fc80ec86-bafd-46d0-8c5b-ca3b4a168d7f">5881479b-e438-417f-8f8b-1823a37444c8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7f4c94c5-57d5-4277-9ca4-463e9d0aaf95">da4d7cb8-1949-46ec-a33c-1969ec711b06</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fbd791be-4860-4879-a7ef-5aed118dee8c">4130cb49-23c7-4ea6-b8c6-2c16b63e7946</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6c33fe66-013c-441e-9081-1f91badbb980">a3606748-3402-4329-a228-38c7446a1d69</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="962c4a18-a1bf-44d2-b9de-5c3ea9bb3246">6693183e-0ea7-40e7-9ac2-589ed5dc23dd</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d06cfe17-3f4e-4323-a60f-5a34e0c994ba">4371ddba-7136-4f8f-90a6-5bd490dcec67</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d45c6db0-0836-4dc3-97ff-3c1fb1ed3c2d">a5d81d49-57dd-4c74-921f-69d8547f2494</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="776d70d9-9ef3-4cfa-a96b-bcf82e9538d4">3d996465-15f2-487f-88e1-69eab018ec2c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="981a9177-b67c-47e2-9e55-c9b59d3447e6">f72710ca-8c5c-48cc-8807-6e0ed252bf5b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2dae1eef-18e8-4d61-aadd-45c04f99373c">fa3db19c-5d28-4f32-b252-6e3c898ad4d7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="660b5942-4a7a-48ce-a7b7-1bdd813b2306">ef67a8d2-d574-4fa6-bb8c-70505d01a437</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="61ce7e6a-5978-447a-b768-e7ab8640a395">3a374e21-5590-4e7f-aed9-835326ce2def</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9a73acf8-44fd-4d9f-b604-35f4d43709f8">8c8e3a0e-1896-4aaa-a64b-83e348a07a76</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="43b3178e-33cc-4d2c-95fb-5753705093ae">7bd587cc-3d01-4ebf-8cbb-930b388cc380</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7cb86913-ab23-4103-85e6-465b06d02476">b83fb9a0-e7e8-4d83-8e7d-96bd3bca726b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9d7dd815-68a9-42d6-948f-75b9275b97f4">4707f71e-3979-47f1-b2b7-974e68f9d3c5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="164a8f02-a1e5-4497-b4e6-e314d05c2f65">adeca51a-454a-4ce3-9a4a-aa5b15b47f16</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d6051365-d331-45c5-ba5c-32f1762e349d">2f40a2a2-e705-43ac-a367-add7787cf652</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3f895da6-4d78-44ab-a328-2752facf67f3">bdc8d08c-dd46-4cee-9b36-cb759fc89ff4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fd68f202-5674-4cd5-883a-2adbe01c5bba">9236fb7b-3765-4b7d-8c79-ce553ce19881</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6cc16cbe-be4c-424f-8b24-5a5a067fb9c6">7abd676e-d17f-434b-bc9f-d358e1cd0cc8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="725bebd1-228d-4086-8450-400c3fca1134">55678201-3036-407f-a34e-e107ee236bfa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9f76feda-a6ed-4749-8db9-9ba575c9dc20">d60935fe-362f-47b3-8335-ea81d78c4491</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.492</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>492</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f9edbb31-dc96-450a-a1f5-dec11703dca9">4219bc7e-8525-4201-9e0e-02340752f27e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="06a76d8f-a8af-48f6-b879-2ac42de3d8ee">d0434f21-40d8-4f86-a80a-09d35556af4b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="508219cc-95b0-48dd-816e-46d52a1ff9de">23da3e09-b37d-453e-bb36-1072c65b9612</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b40e1f72-2716-4096-9de7-1ed35e3e6d1a">78d0216c-8d3d-4287-b8c9-1351df08beb6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8bb37cd0-cf1f-44a6-9603-84bb3d170f75">dfc87195-c06a-4f64-b85d-16d4d359d360</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0c073f32-20df-4300-b4b4-e23003a7afd7">bc66ba5c-6c35-4aa7-bfc6-170c648eeff8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5af22c3e-859e-47de-b56f-d5ac071ac596">2b6c36cc-666c-4716-bb35-1713cf353023</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="76e0a5dc-f4ed-432c-8763-b50fbc61b11e">b1f65aa6-cc35-4d72-850e-19ebf6bc4f65</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ea6fee45-51fb-41ed-8cd8-046c6258c83b">14df4cf5-9594-40b4-8a01-1f6f82bd6a6d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c02056a7-bdcd-448b-bf86-868e3ea21214">500a6cfb-6830-4bbe-8c17-20247df6722a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9d7d2a20-5e40-49c9-84bb-72e20c748476">d4ed28be-09d2-44ec-b86d-249fa076f98d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0bc7d98d-9b07-49fd-8713-3b55dd9023f6">e276abcd-608c-4dcc-a8da-25d91f7d9950</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="185b23b4-0c78-4d60-b937-b6e9b9357a98">07b80778-b401-4a24-9c2c-274a659ed2c2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c8b6b94c-ebcf-4753-a422-a308eea48d75">303556f7-9b28-486e-9ce7-292023c61a68</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2f644838-d236-4392-87c8-64976b5f45cb">bf5ec0cd-d7c6-4997-9fea-2e4d51eb3a90</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6f51be6f-cf2e-4b6e-ac3a-4b5f4d6bb65d">aaa195c6-b7e4-403a-8b08-333f2ca18962</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fa9bbdeb-1132-4691-b5ef-9bf64040bfc1">ee94a24c-3db1-4e4e-8c2a-379f76ad1ab0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7b5abdb0-1072-4d70-a483-471df475fdbf">ad9bc278-5ddf-4755-bd3e-390e792cd2d4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0354f84c-6c62-4559-a68e-08f804f9041f">28876756-6bdc-4d7f-9778-3b3c66a6d31d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ceab23ce-b4b9-46da-88e8-1faa41339637">015cbc58-b678-4585-90b2-3d68f023f38f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="09789649-d6b5-4cd8-a571-5a5965961a33">527fd90d-36da-4ea4-8a4f-402fb2a4764d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fa7885e8-717f-42f4-a927-7a783e6db177">01627392-c904-4f18-9b9d-42a70f0cd75d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ef13c2a5-12d6-4530-8071-4444653ed5d2">804827c2-bd77-4b71-afdc-472d6cac61a8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="42e17199-1a98-4d6a-8e35-934055ecbf4a">3def6495-f8e5-408b-a4ac-4a9e13f6e7ac</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="dae67619-379c-4d58-a73e-60f2c7225715">937a492c-7849-48e5-a39b-5105a21abaca</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="bb0a462c-5f91-49ae-a186-1ea1ed60bf4b">5df76e5b-0672-452b-8b23-51449027ffeb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7b2a5767-5bfb-489f-a575-13d3bf35561b">640ace54-9771-4394-9564-53700a9e9434</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4ab077bc-ae4c-4c79-b3b7-3594577ce34c">bf8cc999-2c23-4bbf-ad97-567e94b1c85f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4a1768ef-8dc0-4347-af94-5829220fb3dc">f7e53952-1501-4c5d-835d-57a3c89dd5c7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="260f446f-c205-41fe-abb8-6beefb7794b1">72cba522-4c11-437c-a823-5d2eb29cec77</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f5a0ca19-2bbb-442e-86e4-90fbfdac7943">fa9558b3-a632-444b-a5aa-6153c0d57187</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e299348a-2495-4b3d-b575-f453ee8260d0">b4c3de2f-f27c-444c-863c-62d6cddcbb15</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ef02f180-f134-4cd6-bab0-1312a9cd0ff8">c09def98-f8b1-4bb6-9acd-687c1e13603b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cf456f35-23c3-48b3-aa84-a7286235ba35">ca748a2b-0b68-4841-8b8d-6ae3ff9b8bbf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2838a7be-a45e-403b-a26f-132ab4ffb804">68ea2c10-1dbe-4b3e-800d-7406f8a88314</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9d12fd4d-9edf-4bc8-8f76-6e9a79fa00da">84a9c500-078e-49e2-9e8b-7429c6614d35</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f9c6fdf3-c8e2-46cc-8012-e8635b07aec8">d2acf8fb-9075-4caa-b383-74f7b830eda7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fbaf71b1-b997-452c-8e34-5f8749a95acc">3d51b374-40fd-4747-bf00-7b60b4d2a0a0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6acccd9c-b2c6-4f99-9a14-8cc59a014e57">b5fb766f-5f3b-40e9-9c57-7c7726b42524</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="043662e0-fc46-4d90-8de9-c84b5f232fdd">41223127-eb7f-4c13-ba8a-7d211c68d436</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9cb8aa3a-51e7-488c-8e38-257ab6dac601">da71fe2b-f268-4305-8de3-7e1b735eca09</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3d7bd80a-ea3a-41be-ae1b-1ad34a720340">2988375c-67ff-4fdb-9577-804e229d0793</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3d7916d0-735c-4666-b850-42484ef2e51c">58f41ec2-5087-48fd-b9e0-909e6ea8edd5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="75781dab-c926-420b-bf1c-40d93898bc8b">70aac665-5753-4e0a-a4cf-983a420079d1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1bacd209-9eec-4cfa-acf8-f8bf67a40ac3">c8aa40ad-7786-4f73-bbb5-a46d5664eee4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9c274087-6a7e-4533-912f-43e8a413ef4f">92435d10-a577-4fc0-99ca-a50ae079808e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="97fb4237-8bf3-4136-976d-65ba79e9cf2e">1f366418-8b8a-4ac2-b7fd-a880bdc4bcc2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d83f422e-d0e8-46d1-a792-b4be8aa89b73">be1e1fdd-00b2-4dae-8652-a8f4fdfd15af</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5d00c60a-46df-44a2-b4fe-e7463751b576">6cd7f50c-1491-4631-9595-a95f801f3aed</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="bdc64c4a-b2e3-4130-81f4-fad2d7058f5a">8edb5ce2-77d7-4a12-9a2b-ac553a236a5b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0fa9db46-ca4e-4f75-a13e-0dc27ee158b4">93e56337-94cd-4a20-a708-ac8a9c380814</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="713216aa-14ba-4c68-b4ee-2ccf225f3b7b">affd7b99-a915-42b2-9b2c-adc9f26ce0e1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="105778b1-dcfb-4529-b655-822ac44565c7">2b7c7aca-686f-49ee-a9c7-b2b341828815</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b978dfba-f542-4531-bf1e-268b9cc2416a">98b9b20a-1c37-447d-bca2-b372275551de</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3c4d3df7-8a6e-4f6e-aa3b-f8dbf4062715">76f4ab50-17a8-48c8-95c7-b656806c6d70</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7021f6ef-2f3d-4488-870e-21f88b12f836">d85be708-1a40-403c-8430-b6577e3a4023</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fbc3cd0a-f735-42e6-97c5-731c27b47c66">ebf34073-fa7e-4afd-81cd-b6ce40d5c96e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3af52e0e-aefc-4c19-9b38-fb240f4bfb26">2c383a40-43dc-4998-ad39-c125c59e7456</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5f1c3dab-dbe5-4506-8491-2c020aeb293a">512bd0cc-a3cc-4eda-ae83-c93231f76871</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="638fe9c1-c909-4899-8cde-65116173800e">f40c5032-5859-4f5c-b76a-caf3fe103f2b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cb439ee4-09a3-4c11-baf6-1108e0f43001">c0c3a111-7208-4a3c-8d8f-cb694e1a88bf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="bbdc0022-8a18-44ea-9171-40a3734207f4">d00da007-7d38-48bd-bedf-cc0ed59d4861</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a9e12419-4a74-4091-9726-f978261e9ace">2f23abc1-297b-495d-813c-d0b4f859797d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d2053148-f613-4dd0-9105-bd3e51916e40">4070692d-c220-4515-919a-d7ff0a5d3c1e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="548c1805-8ef1-487f-9d19-322c37c6d1bf">c08bafc2-d261-43ae-9480-df7683931a37</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f69fdc8a-ef14-425d-a964-c376b178b7c3">a2d949f9-28af-4216-8c86-e158dac3c247</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="986c0436-cd7e-444e-a89d-0fb2c9e37020">29275f7b-a8d6-4636-8e44-e6a4b169ed6a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="888c4caa-e244-42ee-a09b-c09b51216bec">cc83ef6d-5e21-4691-970c-e72bda7c67c9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1f579484-86a3-460e-b42f-810d0be067a4">3233b02e-be36-4ab7-9173-ead6c1b3d44b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3b1e785d-4ad4-4328-9d95-a770040e519f">c93014c3-fce7-47bf-8b06-eb829ff1254c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e309d379-f86b-48e0-819d-a67319729363">e359e60d-fd51-458a-8115-f50170228ffd</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="bd300165-6fc9-4831-9387-34e7d1b9f19a">7830511e-33bb-4ea4-a9b7-f54ffa0613a7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="70457fca-58fd-4674-b6ce-0baddd744d63">fa3afa1b-75e6-45c7-86fd-f6f662a21e36</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e7ec0a33-9629-45bf-94a9-40d5bd9f31b4">bb601121-2f49-4e08-b820-fca2ec56cf10</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e7d0cf17-f26a-406e-939d-0a75f49c518f">c1f5538b-1f9a-407e-a3a6-fe6590e71d4c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7f2992fe-5b7d-4d46-b808-05d2cd49149d">16a6b36e-1ef5-47df-9c23-ffab7996917b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:11:17.491</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>11</m>
+                <s>17</s>
+                <f>491</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="19b70067-7875-4ad8-b364-2f81c90babc5">7315377f-d41e-41a8-a750-02ce27dd404a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8b31dc32-5bc9-4d02-98cd-02877720ac61">6b36b8dd-fc7f-4bf0-a4f5-0993d72bf980</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f05bc3db-fad8-4a0d-bbff-3b23af59c97c">531f3a76-d208-481a-87ec-0b2db2c85b0f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4c648daa-5d6b-4cf6-8fa0-57454a66e77c">1fb8746e-63a7-40b0-8c8a-0bf64b63dc30</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8cad2f6a-2956-40b1-9b42-348bceb1da50">e48f79a5-2a78-488c-aa1f-17c2ce3d0bab</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="49b4d904-7fd5-4951-8209-fdd58f8b2261">28b38e43-e8c4-4f3e-84de-1b2739530a18</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d73bfd07-9cd8-4bdc-907c-4e85340eed64">239d2c6c-7804-4447-944f-33514dd7594c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fd2825a7-e052-4c90-bc3f-faa6e98040b7">c86a0362-e407-4778-84e6-3780ee9b0ac8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="67e0c90c-d2f1-47c6-a3e6-04e18ec05a50">7ec438ee-f098-47e3-8d1c-3fe525aaaaba</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7d237c91-ed4e-497f-b89b-4d1d6fac6155">29bcc897-9eea-40a9-806a-4a14354ca15b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3616392b-490f-495e-864f-f8946a192d02">19bd7b0e-7d54-4db8-884b-4ecca57b2971</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7b0a3e8a-b61e-4750-987c-0a558f9a7cf1">61d7b135-b74e-47f4-8bc1-5afb19ed1e0b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4f7eadda-4f6e-44bc-8ff3-da5de83aded5">822ad7b3-c103-468e-a4c5-6467d6ba0b75</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b0c1e404-bce7-4823-ac65-7b63b4f3b33a">88ef08b7-3530-41ef-833f-649d862d0885</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="773e80c8-844a-4611-8d77-dc8069b14e2b">ba331b2f-b550-479f-ac39-69d450695172</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7928484d-d18c-4465-b4cc-a8c7ed6ca8c1">391d96ec-60ff-4d49-bc65-71a0657bf478</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a1e7403f-0162-4d07-873c-891750fcb932">701e4260-0c42-4c83-82ad-78d2d8682e89</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="397b288d-af96-4386-bc11-a2726cc852ba">fd37a773-7b82-4783-a8b6-7c122c0e85c8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="55840f59-9747-43ba-b094-5afa3ca85cb2">1db9e352-53e3-46bf-8225-87610d1eca07</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0aa0c2e6-e720-4f6f-865e-eb17a63d4154">9400929b-78fd-4b2e-a2aa-93433bd8f3cf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e287584e-2ef9-469e-8fda-d5656bcc0e28">e05ec29d-e79a-45dc-af44-94f384830dae</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1516994c-95fc-4976-8c11-1dc749d62292">2c986fd3-7305-41a8-b832-9ac11bf97f2d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0f1d99c3-3a3c-4594-a7a7-a923f925b7db">f6d9fbe9-0da5-415d-a0c0-9e5bdad4eda4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="79038fc0-28ef-42ac-9c29-d12cdc43a371">b20bcb4d-2c69-40cd-b62b-a383e760b46f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="05233aaa-6f4c-4e7f-9b0f-cea22d325308">1d4ad59c-e92f-4f58-9b07-a4103dfee048</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8b3f6c19-cfee-4f47-bcaf-38398e09e6a7">f58ce5a9-0f9b-474b-81ac-a53b25ee8948</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0522057d-49eb-4353-adf8-c4689c3c2d3d">68104b4d-deb1-4ce8-b487-a975ac72004f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5a3c4d7e-0609-4b63-8746-00569253ffbc">fbb5559c-b86d-42a7-a1a4-af376cb0c77d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9a0f22bc-59a3-4590-9312-6a2a97e18040">77ab6882-d1b6-4c14-a6ef-b7064fff05b4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="564583dc-f604-4703-ac49-bd6fe4cdadf2">cab71763-436a-4c30-84ac-b7ba07bde1f1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2b45f8ed-9553-42ae-8fab-ac0831af3870">2c6c0a62-78d8-40c4-b8d5-bff6f46835cd</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0ab0dc85-82c2-4c11-a5fb-3a46434832ef">959ad8f8-e463-4b30-8d42-c4c88b6e0159</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="30fff76d-586e-4e2b-8c0f-80349ff69fc1">319d20f0-44a6-406b-bbe0-c696dcd18504</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="17e12681-8038-4e37-8c27-1c14fa063bf0">f962f657-3d1e-4c86-8fc9-c78f47247449</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8968a0d7-9762-4b5e-9479-11379ba5bd94">c8d42f50-b2b2-4838-809f-d020350b5e85</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2e61f618-daeb-4bbd-81c7-c23da5198a70">807d886e-6b53-4588-9b2d-db74022e0ec4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="aedbaa74-4e86-4e0d-9a84-228343e23336">485486ac-33c5-4d85-91ae-dce320a49d73</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="780818ed-4fcc-48eb-956e-40a2b428e5e9">a7ab3b6c-e48e-4540-a505-e255f6b6bc0c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d8961414-3f3e-4c0f-855f-4975cdcc0c9d">df6a95ee-2adf-490c-9ff0-f8605b74ac5b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.325</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>325</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="58e10ff7-e1f7-4e93-9eff-eedef095859c">19d6359c-d9bf-400a-a713-035c19016a4e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cd2baf12-1b36-495c-9974-756629a787ad">d47ab144-bc1f-41e2-8e0f-1334abf90446</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c1d5f37e-bbe6-45a7-a3db-cc1815911ada">77b0a4d7-862c-40c1-a451-1439a501c982</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ff1dfd1c-231b-40dd-b286-2740e9b754ae">080aa45c-c570-4132-8d62-170e1acaf599</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="82fdf126-87e9-4c96-8d82-99be3ec6feb4">76fdb0ba-ff33-4398-accf-173ff28ef666</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e93f82d2-8998-404d-9e91-b9b350cfca7b">a50c129b-0b66-45da-b267-1c714bbe7fa3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="eda3ac0f-afa6-498b-9d7c-92231ac58781">388c2142-c6c1-4c5f-9e4e-1d417dda4da1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c4b12c5c-e8c3-4831-ae7a-6612e14fe737">06914936-e45e-4cb3-9077-210247682f78</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fa0fe633-16c6-4b44-a59c-deab3db25a36">9ff6a145-46ed-48a6-8445-26970a441e74</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="45c37956-de3e-4ffb-9d5f-3a02f27666e2">a7695c08-c693-4d41-ab00-274794490d47</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c3f25445-ece2-4ca9-9d8c-064a5cc5354a">763bf021-e41e-4c20-93c3-2a4aca5cb141</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d13bed17-fbd8-4775-877f-417c6edbd3ac">f2b12cb3-eb27-408c-9c38-337263c6bf31</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="20a7a4a6-3873-41d0-ac7a-3484f010b44e">4fb17852-4c1d-4fca-9558-33c3e3252da3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="67b992c9-2051-419a-91cc-f84d59521a49">3ef3e9a2-3b99-44a1-a2d5-38d47a14b5b9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b370b98a-e61f-49bc-81c5-c8f96df6ed30">2426f361-d031-4de0-b003-3dd6ca8aacaa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="49067a6e-cd46-4e29-a1c2-0a474c2f45c1">dccf2e7a-d4da-4bdd-b0c4-3e7da5390334</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="02d17996-7c05-41a9-b6ae-f5c7d6d99eda">825618c7-8254-4eff-9751-4029fefde65a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4a470b0e-aa5f-4d35-a637-2cbafeb9e557">2b55be81-ba7a-4c0d-9957-40a6c0871c55</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="bd0ad23a-86af-47c1-9f26-c7a375847224">61d8c825-cd84-4632-8c28-4159d1ee799a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="80400d53-b847-4686-bb60-8db6bdd5ebfb">721e54bb-04dc-44dc-82f8-474a002cbbb3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d3045872-1d09-4245-bc1e-7d5c3b697c25">c82e1004-5c33-4720-bc81-5d3f2eff2f92</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="508ccd0f-22ec-4684-8a99-5379f9eab701">99717c79-ae57-4038-ac79-5efc1be87f17</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b5e955e2-b696-4ef7-ab3d-b0336fe32362">97c42ea3-5a8e-4bdb-9c6a-67bfa35e8d6d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="acfb1498-3192-42e3-a007-f2262bc4b892">091f2db7-9321-40d0-b5cd-6a8452d9ce95</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e647e732-5b15-4a62-9c3c-28c01a978ec6">4ec51ba1-fd3c-43d9-b5a9-6a9b3c80e9b6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="298b9b70-ead0-46aa-bd14-b15c89c9d88f">31e2fc81-28a8-4796-999c-6e95803955d9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2d021d3e-7918-46d0-926d-09433df6be70">be380e38-ce63-47da-a16b-6ead08a5a364</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9bed9289-7567-4f9a-adf9-0461403227f0">8b5db497-03ad-4593-bd54-72f7404a524d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a6bcb7b0-09f0-4d8a-8c77-b681199cbbe7">a5e6b541-3023-4f20-a237-90706d987a61</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d43f9161-7c8b-4703-a829-b848762e2f2e">171cb873-da44-499b-abb2-97a0786cd3d0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ddb52b3a-7faa-4745-a7d7-821b05591a73">8d9d5146-4e01-47f9-9058-98893a6a44c9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0510745a-9143-42c6-83ae-9b2d1b2d3c32">72a5ceb0-5cda-48be-bef7-9f2993844c74</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6d18ee7e-3605-4428-9132-b821098424d4">d95307eb-c5ac-46db-9cd3-a0fbbd17626c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="91ba16ea-3f37-47ad-9d0c-0a3fbced20b7">0755a6e1-c3d3-4191-9075-a5930658a64d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0220f517-ede9-4a4c-a39d-7c3b071b2e8a">290c193a-b2c6-4f61-be36-a5a129278b63</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ea76a395-3632-42ae-b27c-5df263871ddc">77aaf298-031d-41f4-b1c8-a5d1bdde8cb7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a8514ead-9ccd-44a9-a572-25a5f946bd34">f1e6d162-20f2-4d57-919a-a76ae36b9126</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b10b572b-15ae-4773-aa56-14687ff0850d">1679d6b8-8374-4872-a347-a95e57f17b18</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="24d82118-709e-4e2a-bd9e-598b5c2c94bc">48ec96e2-c91f-4b03-9e25-aaf9f9a43ad9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b09f04e3-0aec-4d99-aed9-8047d0f7b97d">53a576ca-162f-4a2d-a810-ab2e9153f285</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c115e334-bcd4-4431-8ca9-72e5c1520fbc">a729a8d4-0db4-40a8-a247-b3bccf914db8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="090e9a41-0ddd-4ee3-8240-59b7c611c3cd">4c14709f-a4d0-42cd-b586-b4c43493ec02</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b9963ce9-ddde-46c4-917a-9ab9acc77ac0">4f905205-df5e-48ab-9fed-b7950d3a4cfd</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="bbfece46-5c52-4d0f-a2e9-e8497a50444a">b5ef9dc2-35fe-4fad-931b-bc2aa94a7a75</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="abcf0b8f-d405-4e5c-a64c-111921e8faa9">2319512b-efef-4039-bdc7-bef333bd78c9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8287365d-85fe-46d4-bc45-5a724fb7d89a">fb6a2d4d-b11f-4289-977a-c06e07907c5a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="386a288a-ee76-4ad9-a41d-b2a67d0a7646">5d96563e-0799-4405-8fcf-c599291d11cb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="43bfcbc7-86ea-45a0-b3c1-d596ba4e1dd6">22e6f1c4-1373-4a16-850a-c5ba958b3cac</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cbc09222-3414-40e2-9b63-6dfe1ad4b2a1">ed460089-0757-493c-880d-cbf8e0ecb218</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="86d9769a-e184-456c-bec5-2a46f57eb77d">81772d46-c6d0-4a7c-802d-ce6a264b7e68</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4c854014-af27-4bdb-9cf1-041dc7ab7c88">b08fbc7b-5e85-4a23-b862-d0af5bee7346</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ddadbc79-98d8-4c80-9125-9d3450fd514e">d723c154-a8c7-442a-aeeb-d0afd06f9d54</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f613fcb9-fe6b-488a-b131-5dbc6edab92a">2083e0b6-4c66-4ae2-bc71-d4d5e2ecdb97</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="93c05e42-458b-4800-a991-a58701f286f0">424789ea-f248-4890-b7f7-da34cf773af3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="86a50ea4-40bf-4756-9842-03dce4e1f373">b578108d-fb1c-49d5-aa7f-df6825755085</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7f9167bb-bcad-402a-bc54-a4bc36d63b77">2758a642-52ed-451d-bc0d-e7ec69335b7d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0077d2c3-4d0d-4bf9-ab62-afe3e74592e8">41491ce0-39e4-4fa5-a29d-eaa12be1930d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="eae81533-944f-49bd-a4ef-522895429c1f">2d7184c2-7233-4e30-abc0-ec65471eff57</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="05c403ec-17d1-44cb-9958-8059ca508cf4">3429d568-4c34-4e8f-ad95-f8a72f1c10da</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="275f35fa-57b6-472b-9f94-4cdba0f02d5d">ab0e11c5-7a64-4661-8202-ff6272239c73</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.324</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>324</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="020f9eb4-043e-4053-9a0e-f1bfb4181708">949d1ebc-23d7-498e-835a-d386ab517687</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T13:10:58.321</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>13</h>
+                <m>10</m>
+                <s>58</s>
+                <f>321</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0942e694-0b61-4e73-af82-2ddad966d3aa">680ce977-044f-4a4c-a54c-003647cc3723</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7f2f94df-ee88-4218-a4d5-b6013214104d">069ffc2f-8dd8-49cc-b892-00a842728214</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="970e9a5c-4dd3-4800-b019-075f388b2919">23c084e9-3ec3-43ab-8ab9-09e50e06c867</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4bd55752-ff2c-4ed9-93d1-984e1c100822">ff756629-7b9e-4410-8d01-0a84f2fc9171</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f5105b25-e90c-4586-9e4c-753c5d3f33d0">2a268a38-fac6-49ab-a440-0f724093424f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8a25a075-1919-413a-a3d1-99f1d96b8549">fc63de51-234e-4fe2-8126-1136ffa92291</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fc6004c3-bb2f-4e5d-9bc8-649d6425b65d">f7ff9710-2d45-4ac9-86a6-1174bdf4f641</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c2da6eef-047f-4594-a052-eaeaa4b3ed45">94ec3afe-6d4c-472c-8e4c-120dfca86d55</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b6e9e769-4882-498a-b599-57e6e26a0c4e">b8fae182-e01c-44eb-bf14-15c6a8441ab6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f420ea82-24b2-4f0a-8294-a6cd9d00edaa">02318793-991c-479d-8e99-15d2f13ff523</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5f382ecd-e7f6-4f0a-b423-97231e9ba346">2d1a1faf-dea0-4040-a480-15d67c93005a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ffd716d0-22ef-4c01-98fd-d5cb93d5bf41">2eee978a-4c9e-4828-b918-194808c98351</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2465e3af-2718-4113-a8c1-dfb5a3b3fc42">6b6a972d-b388-42bb-9446-1c8b90820aeb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9e7fa85a-4558-43de-942a-ebf7cb6d98f2">984bff9a-f5ec-4c77-ba0a-1cf072f7c074</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="dd160199-a67f-4695-bc6c-a54779063049">2a3112be-e3ab-41fb-bd1c-1f24bca4b4aa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e9b4e5c6-f2e5-4855-850e-d29ead0fcb2e">1ea362f2-e043-4411-a8ea-1fc513737689</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5084636e-1626-446b-b5b4-641c5a9edba5">71ae04d9-fdbf-4303-9bb7-2066ff3f2a9c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a6aee06d-51ca-42a6-8145-8b346de254d5">48a3d4b5-8556-417c-b949-21cfdc72ac4b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a83c97e5-19e7-43f6-9445-4841b00d2c03">8178c06d-464a-49ba-ae4d-266aee8c99e3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="158cd8d9-65f7-40a5-b2e6-9a8a9572059d">de62084a-2538-4ec4-ab2f-282566eb60b6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8fd4d181-3402-4164-b9da-e1a1400e822d">82b35242-b3c4-4f76-b710-2869ed71f04c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8e13fb83-800c-4ce1-b06d-1d695c5d47f5">57360b55-9d6c-4c21-be52-2adf4d6b7389</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="139424cc-9307-4aee-a75c-59dac62a0921">afb93c5c-0750-4707-a704-2b0379a06177</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f8382347-780f-4725-9617-9e46dd6d8d9e">3ea4a83a-3d9b-4bee-bc11-2e276d80d530</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="29d09b4f-cfac-449d-b088-37ee84fa378a">57e623a8-0c60-4103-b9d2-3ae2237a3495</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="04dec3f0-d0c6-4d71-a9d1-126484fdf701">334bb986-92ef-4c0d-96af-3e5e0ced4578</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="040ecde2-05bc-45d3-a328-1d7e81de29ac">cd36e06c-d89b-4d23-aefb-410697af0427</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9afe2355-c1c3-43c4-868f-d2db405113d1">6a392058-85f7-4737-b07a-41f0263aef99</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="28e3cf2e-c126-492f-8a0d-c587840351eb">bf02b5f1-ab1f-4da0-ba84-453e9a5f4e69</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c85bd052-8e27-48ee-a013-713dcb501a03">1b9747cf-7929-4435-8566-47a6ed416def</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fcd5f80f-9533-410c-9b5f-357fb8081245">43d2d39c-e598-4be2-9f69-4addad4d7206</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="92e4bd39-f2c4-454f-be05-fa3c7ec0793c">cbb58446-be58-47a8-8944-5471bc54c989</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9d483535-0f83-463e-839e-b11c0e378e17">cc5d0c50-494a-49d8-a686-578cb062c725</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8fccb9a8-4ca9-428c-bee1-07aad7f6e2a8">cfbee5eb-2b08-4143-8fd2-57b058b88fed</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="84be69b2-d16b-461b-89f9-5bb6450288d0">d343bcb0-9eff-4e44-8a36-57b2c2b1a120</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="765b4215-3958-445b-83e5-2562e0952d7e">fa7f83b7-0a0b-4224-bc93-5aa46fa2ec55</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7890c316-3750-4f46-b6b9-fe13d27397e7">0040634d-258e-41fd-9924-6967edc55a9e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c92b3657-257a-4de2-b1a8-2bcead61481f">7d370cac-4e0f-44be-b773-6a5f8c9dba92</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d1310866-57c4-4ff5-8de1-9e402153f97d">303b33f9-f660-40ac-845c-6c91d9782b05</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="09239c07-2e14-458c-9a50-8a4c3af3321b">86c3a5b4-8881-4223-bb88-6d1cf9b13c5f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4c2ff68a-9367-4d51-a353-7cbdb6e49256">c0464a97-2832-4f50-a683-6d98c396da08</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c3b64bc6-b9f8-45c5-b465-d29fc4c64c33">f1ea0493-40d0-4a1c-b195-711a5110d524</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4d0d039e-d1fb-4aad-8d82-087028c33565">73cc3f1a-b514-4483-914a-72e18e7361f2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f54991ba-216e-444e-8971-35ff174bf4cb">f3191259-b3d2-4c33-b5a6-734dc715700c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="659c8288-2042-4346-b04a-655936e316d1">201d930f-e044-4673-bd58-73d7fb380517</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="195994b6-02e5-4b96-b762-2681daf3aa79">756226c8-7d44-447e-a884-7587b4265046</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="22b0ce29-0dcf-4b36-856b-2b32a1924c16">b5cd4017-6c01-40fe-829f-77190cd1f76f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="da0da2a9-453c-4703-9461-0939d8b40c09">2b9b21a8-a3ac-419b-ac2c-77efe9746756</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="739edd7a-e998-49a4-9258-70ff45d8c228">7bbed5ca-7b86-4082-9d1e-7c8bc2fbcfb6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="eab62fde-638e-485e-805b-ba5bd12b0786">be6fb7d1-0295-4368-8b30-815bf88fb7fa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="69c9e313-c3fa-488e-a4d6-3521e0198482">1d813a56-523a-4ef9-8c03-817144c2a248</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="94a83163-91ce-47de-8bc9-ec2153c0b7ae">682563fa-5ff6-4ad4-918c-893439aa130d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="84930156-9dc9-41c7-be7b-693a6b568d88">49ba600f-6423-4ce3-b582-8a91eae2dd90</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="3a7a01a1-3e4e-48bd-9591-2b71ed96c42f">6d687387-2202-4d5e-8d8f-8c28f08d7382</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="410206a8-0a07-4087-9997-393ee77c00a1">d6a1956e-7670-447f-880f-8c4d7defbe69</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="97c0ca72-374e-43d3-82f6-7e97843d1232">30c5d00f-a3cb-4dfc-b7d8-8eb02d41b0e3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="486ea8c2-3d6c-44c3-a287-af7cb126a3fd">b6b566b1-93fa-48a2-bda6-90cb090ec56f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="814dea49-42bd-4aa5-a058-fa459d7de850">a2e86b52-c045-4b3d-be3c-9156b056ceb7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7ebd8190-1f57-46f2-bc18-1037bc13b160">6582e092-e599-4dd1-89e6-92a5df3f5641</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9c2cb2cf-25b3-4116-8706-6847c8379d04">fe92b921-a31b-48a3-82cd-93d3f5a7d3c5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="553f0412-cbd3-46ab-960d-2227027caa9e">76d13e17-5274-4591-86b9-980c5c1f4d07</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="cd9e827b-96cc-4dd3-b61c-f5e1408f2ebe">d32759f2-9b4e-40e6-80a4-991f4ece70d3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="cbb38ef9-a538-47d0-8ffa-5b2a5cc6c47a">49830fd6-953f-4a17-a772-9f0b152715f1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="de371185-fe9a-4c81-98f4-8ce128c447fb">4a8e863d-a4ca-4eaf-a672-a028d8a1698a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4ef1d4f0-25b3-4bbd-886e-f7213312a51a">3dec5468-8ea0-40ab-be76-a0f5fc8fc5c3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d4c92305-bc1e-4a34-9d7b-db42183df1f6">67c75da9-ec7b-4a65-b27d-a10b0bfd5a09</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="99d9fd07-a98a-4905-a2d7-16b007b7049c">61c8761c-dd51-4ad3-844d-a7420d546a72</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6f82d86f-7121-4dc7-a135-8c12efb6f71a">ab4afd9c-0b43-49d8-832c-a84a850ccdd0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="aa9de184-1b74-47d9-afef-253fe0b7f0e5">59f3be72-9918-47b2-8585-abf04bf754d2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f0a742e1-8f2f-4cb1-a232-5b7011278974">20600f5b-4ce0-4f51-aa4f-acc50b7ec941</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="53f63d47-f14f-4b02-8570-5264059a09af">b693f499-0c65-4148-95cc-ad32edec9250</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4d66c991-4a9c-415d-8fb6-8a26f8865a15">c82d151f-10f4-4047-a935-b0f79224e5e4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="37da1112-b831-487b-8433-5792b8980a83">3c952d9a-35eb-4e55-92fc-b334ec90f320</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8ff9cbd4-1d0f-418e-8d8c-5312c0a25d61">217f9cb9-ce5b-46e9-a13d-bb1ac8f3f2da</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2a9f57b9-a571-40b6-a01b-db86caf38005">2a02fa9d-4500-495e-b23f-bf658f776070</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="eb30e8cf-c089-4bb5-9342-ee91a972ca4d">a52e0613-6c86-4bce-9567-c417dafe1565</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="36a0b0bf-7918-4aa1-b449-4102362d5720">8e7735e6-daeb-4e9a-88dd-c79023d22f33</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="49ef7eef-f07e-43cf-ad7b-e75c97403d1b">3ec65ad2-6203-45af-a0cb-c7c8454f4576</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="53851421-092e-494c-a68d-d853c4b735e8">8bc83557-240f-4bb1-9484-ca6709bf59eb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6e8e24c7-0996-4dc8-9b16-3ec01b98312b">b8caa7e2-46d6-43b4-bcd6-cb7bec983859</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="fecde3e0-72b0-440b-ab49-1550055b7e7e">36039168-1d31-4445-aef2-d0bb492d8111</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="dcc46865-8ef6-480f-bd1c-e20c562ffff2">7128d3d7-729e-429d-b6b1-d4a668d84354</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="193b587c-4d7b-430f-9635-af576a8d3f42">cbc0d0bc-5f6c-4e0a-952d-d4bb690f008a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="32de0891-2274-4580-a89f-16332dcbbbe0">f823c430-c0d3-49e9-859e-dacd59c36be2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="271cfb63-1cb7-4200-885a-dfdf027471dd">6b71aa47-a6d9-49be-9b23-de086743b53b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="de403490-ea45-4b0b-a20d-9f8822829c2b">73b95900-5419-49fb-b47f-dee29ca54291</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="3863e9e4-0875-4801-a913-db1f88ba142f">c93ce737-03a5-4a56-9ddd-e1609febb60d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="abe59a1c-4a9d-4d64-b865-3979d5984ae7">c94b930a-7fe7-48ca-8e4e-e4328d536579</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="fcbb27c7-8c3d-4911-8c0f-efca8f308d7c">a7620a68-dbf7-41e5-9b4c-e5c4d083b4ae</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="dd1bee76-dbb5-4b62-872a-07a9773adbfe">01e7bcc7-1c09-4b03-b486-e8d8083b5f56</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a1d6843a-936a-4b57-bf85-40803deaea33">a1098685-408d-46ec-81ee-e993805261fb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7d506089-dcd7-4869-b437-151148f0a35b">83d84d2c-0f65-44bd-9241-e9ed56824651</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="08f0705e-52dc-4c37-ae6f-f33aa5f3fb8c">1736525e-02d7-44f9-a7c3-eb87a2a24ba1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7d483481-4c12-4b7e-9442-df78d9cbd15d">719909cd-56f6-4f7f-8891-ebfd1a2475ca</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="5e621124-aa0d-42f3-b05e-abb67f9bb5d7">688ad839-6d2c-432c-b8e5-ec9d1e8a2164</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d1a96746-61e9-4b0a-aaad-52676c77ca22">106d860b-bb3f-4ff3-bcde-f35563753faf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c33f69ca-b7c1-42b1-a7bc-e397555a0cc4">bf767376-c8ba-4afd-b4ca-f3a3d35e2fcb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="44af42e4-cd55-41d9-8e6b-5b09ce1896fd">98a757ff-7146-441f-bab8-f529331c7bed</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="53a0bbd2-3d62-4780-afe8-112de6528491">2000072b-fc88-4f1f-9265-f65440f00fb8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="441a1765-5e85-4229-88fa-7a472220b223">16230365-49ed-4083-9d92-fbfe55c79cc0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d9de91af-7b9d-49eb-9355-b44732c8d964">7b9cff25-152c-4a32-a929-063694081cd2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6654e2ec-08ce-4141-bb0a-4f4317ef22fe">fd567762-1a1b-4248-924c-08160cc5e3b6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8dbb2ed7-80ad-41ac-9667-968a5dcdbd0e">63407727-db86-4bfa-948a-09eb9da0fca8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4d3e868c-ac92-4529-9098-a27eae2c6c7e">92372216-eb70-446b-b3bb-0a01d41f22c3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="61ae2b3e-dae7-498f-9596-2a1c7496065e">fd4f1a86-fb12-43e7-8d66-0aef7388b27a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6f42aca4-58af-4775-8318-5fddad5fe0b9">84f51be1-fc97-4931-8262-0e4219d1c6e4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="aa844f11-5b87-4cbd-b651-e9d24495afc4">de60a561-f3e5-4553-965b-1441a036dce5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="e7ccab8b-67ae-45a0-bf7b-84bbf95018cd">374a15d0-f5d5-44f2-a6e5-1a3d7e06030a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6a750696-d957-4013-99cb-518b811ad981">ba223043-f165-4761-a40f-1e82dbcbed1e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="e8748f1c-f1fd-44ed-ad81-3394ada57a5d">99803405-a846-4961-99c9-1f4048ee66a3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="56106a5d-05ea-4adb-a3b7-d0347ab1a547">c77951c9-18a1-43d0-880c-20a672ffe77f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d3e6be47-565b-49c0-9fc1-d0b26199bcb4">642b2af1-fac7-4548-b869-20b8d1b94657</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1d840236-7549-4453-a281-6c25793a8934">b2d846ea-6f5c-4f5d-bfd4-21f3eabab957</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1e71404c-40f0-45f2-85f0-72d3ed1890dd">b9cd8ddd-515d-4d5f-a989-23bb51fac37c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="dcae2d68-79f3-4832-93e8-49a628ea7849">7b9fdeee-fdc1-4a52-a1ae-248ef95c0aa2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="5da44d2f-16ad-49e8-a0c5-394060f8590e">0215ffa7-d3d7-446e-92f0-29f5b2eefd61</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="fdd0b1cf-2bd6-4458-989f-57f483b891c2">85afd931-7099-4d0a-9baf-2f0dbfa5d473</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="5b3269ea-248a-4983-ad31-5ce4784e6306">a3d760a2-986e-4bfa-b87e-32810affc120</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2f6722f7-c70b-45e2-aa21-0c4e956ee23f">eefbb4a7-ad72-41e5-aa7f-32b25ea2b396</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="3b1ff11b-2c1d-4bba-82d4-428ed14639e5">5346f541-c967-4af9-964f-32b282fa54bf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7b000fbd-2871-44f1-9090-94d205660cb8">0fe73171-b683-4f41-853e-3414dc7b5e59</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="3b72d0f9-acc6-4e65-8dc3-e893aa8c69ea">a3c3138b-d3b0-4a71-b945-355ee2c1bdd9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="731b818c-73e3-470f-8fe6-ac8db55310fc">5ce80239-7cc4-4c82-8d1c-3b8ef46e3e3e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="99214fbe-ec3c-46ee-8449-d643075d3c03">e5592ca1-4de4-44ea-a795-3f27dc83baff</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="79ebf796-220a-4352-a266-65bcc5505f76">2e62fbfc-1283-416c-b2e3-43674a8a668b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8ff3ba17-2bea-4af8-af02-dff7947e1f1c">5efd6e6f-86ca-4a13-a61e-45bb694781bc</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1f87de65-d0d6-4bc7-aa24-0d4ee3932636">9bb8b441-1b70-4ac7-a146-460b37684c6f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d09848c2-4583-4ffc-8541-9b049c5d172c">ff0e9206-7695-48cd-a9f6-4879147b8570</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="b1250ba4-3165-4958-99ee-cde9a0f8db5d">90c80938-a536-4aca-9c34-4973aebbf830</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d3ed6e4a-2bed-432e-b1cf-74f986fab85a">ac38dd2b-fa46-4d7c-8ee8-4a0e5f33b1c0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="daccde7c-e6f6-464e-85f1-42f110207b5f">c2d37cba-8f0e-4631-be92-500cc8d7eb3d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7f7a6af5-7cce-4df3-98a4-6bed6cf9ee5b">d1934614-a45d-4e1e-ae0f-5269599c04ce</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="0f678100-9731-47db-865b-74e72e03d432">1b3c00c2-0bfa-4b64-8c61-6057ee85052e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c9755b3d-2f0f-435f-964e-bec94483406b">fac36a3e-cc03-48d2-906b-617e9aed01c6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="df535475-cf01-4f40-aaa3-251052922a15">c5818f93-503c-4b4d-99e4-65975e22b571</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="0c25a58f-4502-4671-b78f-d0131414afc6">cf795229-2705-48c0-a227-6d016d31c381</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1c64ee73-fec2-4dc0-9b92-4b2517b798bf">b8ffcee3-4306-4585-b065-6da0c753df92</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="63d58d0d-5993-420c-a188-26b38cee3e21">395a662c-a45c-440b-9731-6f505e4f2238</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2357cf37-25c4-4589-90ca-fb5bbf7c5c9a">1a13a69f-6cdf-4982-9a2c-71bc108bf945</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9530fa71-e9dc-4c84-a985-f7d5b4fd2510">570e9173-3908-4d80-bbba-7928f0e3cae7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c1a16840-6292-4a58-abb3-6649ee9f8cf0">bc088c33-fd9b-4d30-81bf-7d7233fb6b1a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="502c2739-1d1e-4312-9944-fdf8596136b1">16f66309-e9b4-4b18-b191-807448ed7285</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ad415335-4986-4a70-8760-c3f2f373cf75">02222d21-1e42-4b83-b791-80b3172b6c2e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="83e311d5-d3f9-4ac0-b1cd-d4dd8cbff372">00162394-a69a-410a-9b02-8118a95ff26a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a5269e1d-19ff-4b90-a999-f535f1f9f722">3663d0b1-27fe-405f-b25c-83fa95e16b9f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7d484622-694e-432d-8faa-e3a3244c0a66">81d69ac2-c80f-4d14-99e9-871d8bf56ba5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2752d6da-7834-4186-93a4-b782683b22ff">cf257778-dbf2-47f2-b2e2-8e5d4cbb7b5d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="219ed7a7-901d-4283-b6ca-86c0ef2e8cb5">31ea2013-4701-436a-8f12-9012f42fdb84</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="add253d1-73c4-43a1-b118-c49f14c2486e">b19ff32e-2dca-43d4-bab7-9bbc688f3ac9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6f2a6f75-b78a-456e-bab6-17f8d569e3d1">031a8473-0c0f-4b40-9d63-a00ad9d8b98b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1944cc86-cb0a-4586-998c-793f6cba7892">6ee5cb1d-bcec-4cb5-b0e6-a09cea67e556</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f1e20c83-d27f-42dd-9dfa-af71dfd263a8">bc7b96a9-8795-4df8-9e2e-a4a7bc005201</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="db617f06-c9b7-49f7-a667-20714828157c">ab493869-b70b-41a1-a4eb-a6372ca9d187</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="b4ded7f1-93e3-46d6-8cdf-2ef47d04ca4e">a1fc08be-33c9-4997-bc9a-a72e2504649d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="dd78d6ee-8403-41e8-a887-a7c4b63ad545">d78180b4-b41c-4bd0-822d-a74a181b2139</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c78e42c8-4640-4ab2-bf5f-8062ac356753">22a04c16-ffbb-404f-aac2-a9bc41dfa73c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f938de36-a152-4fdd-9fcd-17a338011e72">a4f25ad2-8481-4ed5-95f6-abc8ded7e5e7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ecfdc4db-7d9d-4b2a-b84e-5d853ee99901">6a9f651c-7952-4539-8c4c-ad1558e906cb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="607a6508-cde2-4eee-a289-938f83eae934">7a29ac8b-932e-4ad9-b98d-b2b6da458cd4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="101a0dcf-16f9-4312-9a0f-2a75e02cd698">ca0dbca2-497e-45c3-8df0-b40cd6e88c4c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="e1027ef9-cc5b-431a-b8e4-e32abece07b0">09c36a02-7ca4-45e1-9a07-b9e7230086e1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a0378b02-fd31-4815-9e3d-8f6ff9662e95">62149b2c-cda5-4216-a6bc-c30d7d23ec02</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="e2c1bd0c-b2da-4f23-a35b-f5ba7ca333ce">ce8df54a-a636-4e12-af22-c59e6dba7141</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2f0b07a0-64f8-4f84-87ff-72b0124cf95a">437f6345-258b-47c9-8df9-ca6c38d9f58c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d8029307-5a5b-4f5a-9b70-549047240dc6">2730817e-79f6-4b60-812c-ce99f02b60ad</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="779130fa-aeaf-4399-ac96-03b662be3eed">36e3b39e-7c38-476b-b46b-cf68c4349847</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="fa71face-8f51-49d8-abb9-87306d334fcf">4e3ccacc-1d97-42cd-a466-d17a693a5faa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="be2fde8a-6c89-4e78-9eef-5d51fd3729d0">7aab1f18-dde0-49e5-b09a-d20b58dd5ba5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a2dc288b-6437-4574-9732-f78f7aeef142">153de734-6421-435d-b919-d216bc95a2f9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="15bc644c-4099-4a43-b8a2-058daa27dd70">c59e3f05-515c-4ff6-a808-d6e7d57e0879</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f14a7c76-67a6-46af-9801-9396fc9c6a3a">278a0edd-448a-4382-8e1b-d88426d03f36</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ba764067-8368-4075-a7f3-fcdf82ed6ae4">85b8c779-1ffd-4ceb-9359-d942e45bf4c4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="61fee4e7-3dbf-499c-b415-185b00645eac">e552fb0f-635a-41f3-8486-da4b56e62453</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9facdf63-4eaf-49c0-984f-f26df26bb759">c18e44c8-0380-445e-9209-dbdf763c4d1b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7f8a8f69-d6d6-4945-a0d7-ccbf4fdcea65">2c958738-2370-4469-9b53-dc048687e3c2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9b00c9b9-355a-4f28-b964-21404623807b">5c3325e0-ff5d-4b3f-89a7-dd3921bbd5f5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="80a0a754-fa9c-4249-9f9a-59d425cf8103">3f7729e9-71c3-4ec5-87af-ddb460bfc050</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1ea59bb9-9fe3-46b8-a8c5-31a66aa27004">9e98d63c-7941-435c-8fc1-e09603ee515b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="61576ad8-d0ee-426b-b0ac-ddef71741c0b">1db2a9ba-426a-4608-995c-f2c4a06909d3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="77d092ba-2a0b-4203-93af-b0d17f4437bb">e3b911d3-d451-4bec-ab14-f3bb7443a7b0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d8867e03-e052-40fa-8674-822e5545b78a">b1a087d7-b91c-414c-95d0-f768bac2b284</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="e804880a-9e6d-4c45-a744-18a99c692bac">0e5659a8-3b4d-4115-8b58-fcc2e87d93d4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="49a9ad59-cb1d-4106-8763-b2187a009202">287e5814-ac40-48c1-9b31-ffcdbb395221</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7c470f10-b829-414a-99f0-0f19e4cc1b10">800e0fb8-1498-49db-b7a8-04b82d7e6d76</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1457568c-549c-438e-9101-bec4044471de">e85f33bf-c251-4121-b2ee-1911ac550a0b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="68aa88e1-0e61-45e7-bd1d-6aa81361e88b">9e10e4a0-dcb9-4ecf-8c62-1d5318d83bcc</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ecbbe983-00dc-4790-9d78-2b241f8107b3">d2121e86-57eb-4dce-b075-28ebbb2d26b7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a43ae4db-5b6f-4282-a436-4099d26fb8e8">b0a86d83-a4f9-4209-854a-4c06ecd06bab</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="714ea834-ba7f-4062-b84f-19c05994320d">c60de1aa-6c7f-419b-9190-5bceeb633a85</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7200a17a-7dc0-46f0-9182-b869c602afab">8f44df93-2704-4353-a195-5d9419f28b87</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f8524b8e-aab6-41a0-930d-2624ec6263ab">b3d584a4-bc83-4eca-9f8d-6fc44398907c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4d8041bf-f87d-42ff-a0f5-e4f18f3a8197">b806280b-245f-4187-adb7-957c0b63ba30</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="40d3fcb0-6be5-451e-9af4-c01384d18f3c">b6b2c81e-1b88-4ac8-ab52-a58b6404ef1b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8e783740-2f6e-4764-ba2e-ca576bd41773">a66e71b5-6a44-4473-9dd9-b715765a25aa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a5d22cc9-939e-4312-a715-1e07f72c11b9">7c6c2bd0-1adf-4d29-a850-d090ef0516cd</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="18052cd4-5ac2-4fdb-b2f4-a5a37e18a972">74faa004-13af-4145-bad8-e393fad4cfbf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c1348f85-d5d1-41fe-9e16-76233b2c8ec2">9158925a-a900-440a-aab6-f59ef3b8633e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="fc335b8e-ff41-47aa-b781-5cdabc8eb547">9571d7c8-848d-446f-a5f6-f80613f647f7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1087f13e-b738-40e8-a2bb-6d36b1dca723">13aff0c2-4ca5-48a2-a8ae-f8e57b801018</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f081e06d-5135-4507-9ce5-4e5ff256848a">14510134-7f69-428f-b625-af0d7e380877</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:43:13.977</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2a04bd03-d504-4f7e-8293-3d2b68305da7">354492a4-d8c4-4414-8c5d-68aa7d22a0eb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:38.228</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c1eb443a-241b-4dfb-8816-5651a9276664">c65c4311-46c6-43d5-86a1-ef63fef99bd1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:38.014</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="5986552d-c213-4679-bb87-4edce4dfc7f1">0d384d86-96cd-4277-ac00-ea7af2b946ce</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:37.816</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="0b03a257-b1b3-4b10-bffc-de558714fb12">576e8ec0-e055-400a-9c7e-af3b7b95f56e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:37.624</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="b003f73d-7e17-473e-81cf-d14e1b7f328b">1c2bf4d8-2ac9-4643-8e5a-7fe2a5485f06</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:37.43</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="25d77644-9b6e-434a-9af6-33c09244b030">266451b2-57e1-455e-beae-a08fd4756435</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:37.225</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6d1fdf81-dc3a-4ed8-8b90-0fa0e468b5b3">590fe18a-10fb-4602-90e4-226a74fec4f8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:37.018</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c8d4a519-560c-41aa-86bf-a835c0e69ca7">2c37fb55-eeab-463e-9f9a-1d10eabf9e65</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:36.848</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="0ab00eff-6e14-42fa-a705-250c63a5bf69">716aabf7-c516-484e-bd5e-c62a2c81208a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:36.692</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="05945bb6-8017-49bc-b0fc-58f7f34d84c5">623ecb77-e5b1-43fb-a1e8-8e596a5b7431</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:36.52</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9057b1f4-688c-48b5-b917-66f200b66677">5e507cb6-a977-402e-8876-204f299b01b6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:36.314</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f504405f-dfc2-4af1-90e5-b939b23084a2">73e5c4f2-e95c-41ee-9ce6-c9e08fae1e93</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:36.091</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a0ce9542-7ebe-4399-acd3-69307072e762">d466201e-90dd-41cf-a31b-1eae1e162ca6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:35.88</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a690d69d-ea01-4b04-a3c8-1cedeaf73f65">c92bc382-a734-4bd9-a9ff-da1e3e3c05ff</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:35.664</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="52dbcbd2-6ea6-4f08-8826-69197efba8ae">9322c339-8200-42e7-8951-c09600b25961</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:35.476</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="5ec4862d-36d0-4661-ad38-fb1ca992f95c">3283f2b9-4962-4af8-b09e-87b23baa8648</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:35.272</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8f836ca2-3bb3-4918-9ed4-755bfde0b76b">fdfd3ea5-1033-4da4-8a47-2e1c7c298582</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:35.059</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="5015ae3f-8d92-4a48-b44a-5749a84ec6d6">e76dac6a-d7de-42c4-b301-c2082ff56080</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:34.861</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ebc6d069-03cc-4c22-ad78-c0391e4c6c79">397a6058-778d-479b-abc4-772050e8be95</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:34.626</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="00d365e9-1104-431a-bd7a-c26b6a62d8b4">c24cc866-4788-465f-9de8-e00c3cf8060e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:34.442</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7f02c18f-17af-4b49-a590-9a3811cdfa8b">d417c11e-40ab-4ec3-b3f3-63a0da618a73</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:34.248</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8d4f3e7b-4b1f-4ab3-9be1-3c99c71c39c3">3418539e-8301-4d03-ba41-e81020ee9e37</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:34.067</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="fe650cbe-4080-4f72-a7d2-6f8b435d23e6">14c7392b-c520-47b9-a08c-81e9ef17bf54</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:33.89</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1263cfc8-0525-4567-93fd-a226842d6f4c">e35cb64d-8e29-478b-9660-db1d1a908b6b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:33.688</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="7574e6d1-502b-4823-b76f-76599b13db3e">66f840e3-5822-4874-86da-4c77d64991d7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:33.501</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8950aed4-940a-419b-9020-5143931531d3">b61192b5-2a89-42a5-b84e-d537d0953f6d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:33.3</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ee5ed923-379c-49aa-895f-505001ec042a">368acfc9-2ca5-4968-b2e2-d9c621ca0176</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:33.122</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="369cad10-bb68-4855-a71c-f758deecfcda">c2633048-c0fe-41dd-bb53-786d9dd6e0d9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:32.918</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9d9dfbe4-652b-40af-94ed-a1b55c5176c4">f41bc588-b5fa-4cf5-9c4b-4acac010f1bf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:32.73</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="89b2fe81-3de1-488c-b04d-a48ea736edba">0ac4b46f-1b1d-4078-a457-dc251d2976e7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:32.529</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ecd53084-6c2f-4074-813a-66c4067bd617">3075bc40-acb1-45ff-a5f0-1f3354347471</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:32.332</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="34c0566a-eb09-4937-8313-67523fc11c97">75f90e06-594f-4a7d-ab42-ee94246c9730</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:32.132</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4adda3f3-28c8-4a11-93b8-71e8e1b85100">635be9cf-e6e1-48a5-85e3-e3aea18e8f59</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:31.972</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="90944ae0-4206-4007-912f-dc745e528a93">c0478d39-8fff-4e48-aaad-48ac73a2db24</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:31.806</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2f443182-8caa-4fa6-8d70-cb060ad2663b">826c7af5-5e1f-407f-95eb-dd27638f335c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:31.627</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="10519477-3eba-45df-b8ad-eb52d3f219f7">28c54192-6a8a-4029-9a98-fc710d6d0983</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:31.437</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8ab43c62-bbea-457f-b26b-9bd501e520c0">dcfeb7f9-5d4e-4c5f-b6a3-0c8e1e75271d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:31.265</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="afa44018-eb04-4347-ab1e-5e20d2e1dcbc">e1002346-1ee2-4779-a54c-bf2504ae4ebe</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:31.042</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="024c4fb8-530e-4928-8f32-90228acb2066">f7c76f77-e066-4993-b0a5-bd1477521735</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:30.876</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="32e618c7-cc28-42a9-9673-62d67fe91f15">012a9cab-65b2-4654-b116-0b1411d5db03</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:30.688</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="225a66e7-493c-4861-ba25-e0353275d9cc">a299d933-5c1f-4b6a-9e53-333dfaff35cb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:30.507</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="28cf4a3d-f7eb-4965-9d3e-6d4e1b891173">c93689d5-163a-42cc-9efd-27f22874987a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:30.293</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="a8630667-3c90-44e3-a6fb-31b693b16a25">0b68d06a-749f-4d78-8bc8-02219398db01</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:30.1</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4ae4c390-675f-4637-90c5-cbc6fb69d170">9695fbf3-ddc6-4a16-b339-24ecc4617ba5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:29.903</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6b1332c5-451f-4a05-a54a-f0747fe88d2b">af7c3eac-7494-4085-8a48-f9562c587f70</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:29.73</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="78b78a09-691f-49fb-a214-c5c2dc5158f7">ba18f019-3c31-4a12-9d99-900050db09c1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:29.541</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8dd14f40-f806-4b85-842c-e828f99d84f3">20e31efc-daa4-43d7-9d2e-d16eaa402e8a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:29.353</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="e166161f-2295-456d-a5e0-1e1b29f69f88">783f1e34-5a7c-4db3-925c-3cba8ae01961</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:29.128</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d9c91ac3-effa-401b-8979-c074dd246d33">f0a36c60-e397-43c6-85b4-a9545ef639a2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:28.95</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="cb4995c2-e516-43df-ae27-fdc415104380">1c11c629-e15c-4d76-86a2-559ea01c8a0b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:28.746</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="165cb8cb-8c35-4ff3-851f-568496ca97e8">ce456e6d-3f92-47dc-8636-678c2e70791b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:28.574</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="3205ca2c-2008-4084-a948-99c713708814">c2da6be1-aa78-423c-adf4-dc854462e4c9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:28.352</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="fbb7c6c0-a791-478c-8517-04528c0db54f">bc31ddb2-bda9-4f5a-b231-1b5361827036</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:28.153</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="86ec6fd0-1c5b-4eca-af9b-b08162d799c1">be1c0694-5f5d-47a6-9227-9f8c59dab286</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:27.969</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="c15fd9f6-7f7f-42ba-abfe-5a9d0c0a6534">b87d215b-9904-45c4-8bfe-ea8feae30449</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:27.771</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="02e98fbe-76bd-4761-a4b7-794646fe5f50">12c3455a-b128-4f62-bcaf-1a7906653250</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:27.594</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="05eb174a-727b-45c6-aaa6-6ebcc6e1a911">b46514b9-49af-439e-83f7-98c1e3fbeed3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:27.413</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6f8ac174-8d32-4a0c-a063-a835a3205bdb">c3093d42-690d-4bd6-9917-9ce4099e03c7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:27.199</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ac007881-efcc-405f-ada9-e78626ef2521">adc5d8bd-902a-4492-9a8f-7b16297973b8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:27.013</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="cb5e092a-1a9c-4a43-b9f1-297534141ab3">3937d1da-c068-405e-9ff0-d229775fa2c9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:26.834</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="b6682775-8158-440b-abf9-9fefc7ac37cc">a209a7af-30d0-43ab-bdf3-9a0d89d5f7a2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:26.631</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="84846ae2-b5ad-48a0-a093-ccbde411abc5">874b5aeb-8960-4171-8b4b-2a65e597c54c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:26.453</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="734c7d57-e4a2-46bf-a15c-121a5ba10717">10597bca-0da8-4926-bd1f-07c58fe3591a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:26.266</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8349dbe3-6460-43c7-9bd5-2e41b94cbbe7">9838b229-8e17-4a20-a17e-2563ff476f71</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:26.071</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d019a866-a88f-49ef-8d3a-95ae83a26523">aad6685c-32e1-47b3-afe1-0bc0674f6268</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:25.904</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="6cc1063b-fa3b-4fe0-a7e4-f8cdd43e6875">97a6897a-d196-411c-a9cb-080007cb7e58</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:25.688</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="0149eeb5-67d0-4116-b2a2-976288d03731">ca12568e-892f-4c50-abe3-47dc3c685d31</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:25.533</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="cef9e96f-8eb2-4e1d-ae05-53124f1a381e">16221b90-ba65-49d7-9b93-8cf46b451de7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:25.339</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9009468d-9fc5-40c6-b5b5-68653781f7df">f8e386cc-3401-4a41-acf4-c0c785d5e4ea</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:25.153</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="e87375e0-81f0-4bcf-a704-a60c0f5f0ca1">54c3092a-c769-4a10-a8a3-f068d3752881</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:24.979</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9b3a9e88-7356-4f83-86a6-ed4b4774265f">ca4b3bcf-a4a7-45f4-828b-2856f814ee80</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:24.798</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="bbd646de-d11c-4b54-8397-b3bd3f9e1ae6">b9b60972-ace4-49cd-b0c4-b7e68bbca72c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:24.619</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="59a9fdbc-5b5f-4697-bc03-442d09968615">a6b505bb-1f35-4fa0-9595-811b456cbb91</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:24.44</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4aefe730-963e-41bd-97d3-33eff14ae217">fa792001-47ac-4d0e-9027-37b1225da673</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:24.238</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ba9e5a99-c278-4347-92b9-837734605fb4">83bac34b-41cc-4c11-b6b6-8f6092684913</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:24.058</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="575d8b2e-6ccd-4cbc-9917-70546080e1d0">b18359d9-726a-4e67-be30-3eb26597b2b5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:23.871</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d0bea6b2-7389-4c52-8515-f7a6f1fcfdcb">d2317ef1-1daa-458f-a05f-6546cc888203</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:23.688</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="faa7e53c-d8b7-4eed-8e37-7e4fffc0554e">defb0f11-aa25-4e28-97e8-0df118ddd4bb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:23.487</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="857a543c-cc81-46a3-94e5-72bd8a5c5c6f">2461b54e-a33b-4c96-8ab7-a1efb0bfcfa9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:23.313</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="cbcf2046-577a-440f-9c8f-503f5b08761b">fc1babf0-e3e2-46bd-b3ae-327dcb881c1c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:23.128</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="55d620f9-99ea-4f81-b186-ab2a04522061">f5f2c6f0-6924-4744-9338-8e3d81c31259</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:22.942</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="b004a256-2e03-4cb6-8372-fad379d3c7bb">990cc5b1-933a-410a-92f2-2669343f9bd8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:22.767</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="4a75442f-4867-44f1-ae4d-a0451c1d4131">5cd0581c-d160-4f6a-b64d-2210efb6f4a9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:22.597</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="d29993c4-22a4-4952-9a2e-71c74f1a3946">79fc5081-2b3e-4245-ac28-821f4bfbe9e2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:22.41</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="439b859a-b0ca-4190-84cc-d481314be10d">902e028f-bf04-4e24-9faf-69f4e79f8195</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:22.216</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="1e387f67-c94d-43f0-a55f-57bc17935343">b1ad799a-7984-431b-8ae0-ba3dbb5380c7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:22.013</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="af0e5b43-788f-42ab-9030-68ec30ea3dcb">0f73d0d4-164e-47ce-8944-1a377c3c2d5c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:21.831</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2beb3260-b233-4eaa-a570-01b763127656">d97cd429-be2e-4c3b-916b-072e285a5902</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:21.638</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="cac41aa2-ac33-4339-a886-6bed9285fda2">fc0f81e2-0c4c-4237-add6-9ec9da5105f4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:21.478</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="488818c6-f0ad-4a71-a739-cd63369a1070">d3a528c0-0036-4108-9a25-60b6cf29fec7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:21.31</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="349bd092-ad55-4235-8f3d-cd652647810c">fa977fd6-b488-44df-b971-0d11439cd61d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:21.159</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="62398329-9265-4f48-8926-82ed46745a6f">674321a3-c22b-4afd-b687-e39c4bc499cc</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:20.97</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="f77b81bd-fd31-4c28-93f4-e1b20fe40a98">912bfba0-9acc-4d39-b346-33abfacfb201</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:20.814</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="36e9b051-7bd1-4f51-9efa-af76f51acfe6">3e414c0c-4c1a-47bd-bd4c-1a33534dbdeb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:20.629</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8a6cb0c4-5fb0-4600-bcce-550ad70c0fa7">0b1ed5a4-3456-453e-91f7-6d22a1d7bead</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:20.407</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="86dd5ee1-b499-4095-9650-10893d2ea0d4">8f9ae913-4bdb-44a3-8bd6-8fee506ed5c2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:20.231</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="07a73e5e-ef62-4438-85d6-f94b30e7563c">3ee73717-661e-4f31-9ec9-867676cd9e08</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:20.048</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="09cb8e84-2757-4ced-8a29-47d43a2b8b87">4a449d31-a1ed-4035-801c-7e36a9b75145</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:19.853</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="0acfd944-e550-4e70-a430-a6c591208f1d">f2f09439-2eca-4ca0-a061-efa39c693462</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:19.668</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="ed1879a3-13d9-40bc-95d8-e873721c1c63">05a5018a-20ae-4eec-bab3-9c7b1e48a420</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-23T12:41:19.35</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="9b379300-bb6f-4d46-8ff0-328a04513f30">295eda72-9b30-4811-82ab-33d34b979705</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-10T00:00:00</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="2a0e1f1a-3a61-4446-8d28-4ffbe6c9350f">a1a6ab8a-7169-459b-98e1-9d6d880098b5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-05-09T11:00:44.759</eff-date>
+      </unprocessed-thing-key-info>
+      <unprocessed-thing-key-info>
+        <thing-id version-stamp="8ca1fe29-ee44-4187-9255-2cef77f965ee">09883e46-7bfd-4af4-9026-0b5b9fbd77a5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <eff-date>2017-03-23T12:39:48.107</eff-date>
+      </unprocessed-thing-key-info>
+    </group>
+  </wc:info>
+</response>

--- a/Microsoft.HealthVault.UnitTest/Samples/ThingsPagedResult2.xml
+++ b/Microsoft.HealthVault.UnitTest/Samples/ThingsPagedResult2.xml
@@ -1,0 +1,6490 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<response>
+  <status>
+    <code>0</code>
+  </status>
+  <wc:info xmlns:wc="urn:com.microsoft.wc.methods.response.GetThings3">
+    <group>
+      <thing>
+        <thing-id version-stamp="4c2ff68a-9367-4d51-a353-7cbdb6e49256">c0464a97-2832-4f50-a683-6d98c396da08</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c3b64bc6-b9f8-45c5-b465-d29fc4c64c33">f1ea0493-40d0-4a1c-b195-711a5110d524</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4d0d039e-d1fb-4aad-8d82-087028c33565">73cc3f1a-b514-4483-914a-72e18e7361f2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f54991ba-216e-444e-8971-35ff174bf4cb">f3191259-b3d2-4c33-b5a6-734dc715700c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="659c8288-2042-4346-b04a-655936e316d1">201d930f-e044-4673-bd58-73d7fb380517</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="195994b6-02e5-4b96-b762-2681daf3aa79">756226c8-7d44-447e-a884-7587b4265046</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="22b0ce29-0dcf-4b36-856b-2b32a1924c16">b5cd4017-6c01-40fe-829f-77190cd1f76f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="da0da2a9-453c-4703-9461-0939d8b40c09">2b9b21a8-a3ac-419b-ac2c-77efe9746756</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="739edd7a-e998-49a4-9258-70ff45d8c228">7bbed5ca-7b86-4082-9d1e-7c8bc2fbcfb6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="eab62fde-638e-485e-805b-ba5bd12b0786">be6fb7d1-0295-4368-8b30-815bf88fb7fa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="69c9e313-c3fa-488e-a4d6-3521e0198482">1d813a56-523a-4ef9-8c03-817144c2a248</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="94a83163-91ce-47de-8bc9-ec2153c0b7ae">682563fa-5ff6-4ad4-918c-893439aa130d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="84930156-9dc9-41c7-be7b-693a6b568d88">49ba600f-6423-4ce3-b582-8a91eae2dd90</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3a7a01a1-3e4e-48bd-9591-2b71ed96c42f">6d687387-2202-4d5e-8d8f-8c28f08d7382</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="410206a8-0a07-4087-9997-393ee77c00a1">d6a1956e-7670-447f-880f-8c4d7defbe69</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="97c0ca72-374e-43d3-82f6-7e97843d1232">30c5d00f-a3cb-4dfc-b7d8-8eb02d41b0e3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="486ea8c2-3d6c-44c3-a287-af7cb126a3fd">b6b566b1-93fa-48a2-bda6-90cb090ec56f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="814dea49-42bd-4aa5-a058-fa459d7de850">a2e86b52-c045-4b3d-be3c-9156b056ceb7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7ebd8190-1f57-46f2-bc18-1037bc13b160">6582e092-e599-4dd1-89e6-92a5df3f5641</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9c2cb2cf-25b3-4116-8706-6847c8379d04">fe92b921-a31b-48a3-82cd-93d3f5a7d3c5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="553f0412-cbd3-46ab-960d-2227027caa9e">76d13e17-5274-4591-86b9-980c5c1f4d07</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cd9e827b-96cc-4dd3-b61c-f5e1408f2ebe">d32759f2-9b4e-40e6-80a4-991f4ece70d3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cbb38ef9-a538-47d0-8ffa-5b2a5cc6c47a">49830fd6-953f-4a17-a772-9f0b152715f1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="de371185-fe9a-4c81-98f4-8ce128c447fb">4a8e863d-a4ca-4eaf-a672-a028d8a1698a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4ef1d4f0-25b3-4bbd-886e-f7213312a51a">3dec5468-8ea0-40ab-be76-a0f5fc8fc5c3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d4c92305-bc1e-4a34-9d7b-db42183df1f6">67c75da9-ec7b-4a65-b27d-a10b0bfd5a09</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="99d9fd07-a98a-4905-a2d7-16b007b7049c">61c8761c-dd51-4ad3-844d-a7420d546a72</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6f82d86f-7121-4dc7-a135-8c12efb6f71a">ab4afd9c-0b43-49d8-832c-a84a850ccdd0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="aa9de184-1b74-47d9-afef-253fe0b7f0e5">59f3be72-9918-47b2-8585-abf04bf754d2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f0a742e1-8f2f-4cb1-a232-5b7011278974">20600f5b-4ce0-4f51-aa4f-acc50b7ec941</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="53f63d47-f14f-4b02-8570-5264059a09af">b693f499-0c65-4148-95cc-ad32edec9250</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4d66c991-4a9c-415d-8fb6-8a26f8865a15">c82d151f-10f4-4047-a935-b0f79224e5e4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="37da1112-b831-487b-8433-5792b8980a83">3c952d9a-35eb-4e55-92fc-b334ec90f320</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8ff9cbd4-1d0f-418e-8d8c-5312c0a25d61">217f9cb9-ce5b-46e9-a13d-bb1ac8f3f2da</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2a9f57b9-a571-40b6-a01b-db86caf38005">2a02fa9d-4500-495e-b23f-bf658f776070</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="eb30e8cf-c089-4bb5-9342-ee91a972ca4d">a52e0613-6c86-4bce-9567-c417dafe1565</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="36a0b0bf-7918-4aa1-b449-4102362d5720">8e7735e6-daeb-4e9a-88dd-c79023d22f33</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="49ef7eef-f07e-43cf-ad7b-e75c97403d1b">3ec65ad2-6203-45af-a0cb-c7c8454f4576</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="53851421-092e-494c-a68d-d853c4b735e8">8bc83557-240f-4bb1-9484-ca6709bf59eb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6e8e24c7-0996-4dc8-9b16-3ec01b98312b">b8caa7e2-46d6-43b4-bcd6-cb7bec983859</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fecde3e0-72b0-440b-ab49-1550055b7e7e">36039168-1d31-4445-aef2-d0bb492d8111</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="dcc46865-8ef6-480f-bd1c-e20c562ffff2">7128d3d7-729e-429d-b6b1-d4a668d84354</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="193b587c-4d7b-430f-9635-af576a8d3f42">cbc0d0bc-5f6c-4e0a-952d-d4bb690f008a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="32de0891-2274-4580-a89f-16332dcbbbe0">f823c430-c0d3-49e9-859e-dacd59c36be2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="271cfb63-1cb7-4200-885a-dfdf027471dd">6b71aa47-a6d9-49be-9b23-de086743b53b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="de403490-ea45-4b0b-a20d-9f8822829c2b">73b95900-5419-49fb-b47f-dee29ca54291</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3863e9e4-0875-4801-a913-db1f88ba142f">c93ce737-03a5-4a56-9ddd-e1609febb60d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="abe59a1c-4a9d-4d64-b865-3979d5984ae7">c94b930a-7fe7-48ca-8e4e-e4328d536579</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fcbb27c7-8c3d-4911-8c0f-efca8f308d7c">a7620a68-dbf7-41e5-9b4c-e5c4d083b4ae</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="dd1bee76-dbb5-4b62-872a-07a9773adbfe">01e7bcc7-1c09-4b03-b486-e8d8083b5f56</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a1d6843a-936a-4b57-bf85-40803deaea33">a1098685-408d-46ec-81ee-e993805261fb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7d506089-dcd7-4869-b437-151148f0a35b">83d84d2c-0f65-44bd-9241-e9ed56824651</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="08f0705e-52dc-4c37-ae6f-f33aa5f3fb8c">1736525e-02d7-44f9-a7c3-eb87a2a24ba1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7d483481-4c12-4b7e-9442-df78d9cbd15d">719909cd-56f6-4f7f-8891-ebfd1a2475ca</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5e621124-aa0d-42f3-b05e-abb67f9bb5d7">688ad839-6d2c-432c-b8e5-ec9d1e8a2164</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d1a96746-61e9-4b0a-aaad-52676c77ca22">106d860b-bb3f-4ff3-bcde-f35563753faf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c33f69ca-b7c1-42b1-a7bc-e397555a0cc4">bf767376-c8ba-4afd-b4ca-f3a3d35e2fcb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="44af42e4-cd55-41d9-8e6b-5b09ce1896fd">98a757ff-7146-441f-bab8-f529331c7bed</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="53a0bbd2-3d62-4780-afe8-112de6528491">2000072b-fc88-4f1f-9265-f65440f00fb8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="441a1765-5e85-4229-88fa-7a472220b223">16230365-49ed-4083-9d92-fbfe55c79cc0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:27.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>27</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d9de91af-7b9d-49eb-9355-b44732c8d964">7b9cff25-152c-4a32-a929-063694081cd2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6654e2ec-08ce-4141-bb0a-4f4317ef22fe">fd567762-1a1b-4248-924c-08160cc5e3b6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8dbb2ed7-80ad-41ac-9667-968a5dcdbd0e">63407727-db86-4bfa-948a-09eb9da0fca8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4d3e868c-ac92-4529-9098-a27eae2c6c7e">92372216-eb70-446b-b3bb-0a01d41f22c3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="61ae2b3e-dae7-498f-9596-2a1c7496065e">fd4f1a86-fb12-43e7-8d66-0aef7388b27a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6f42aca4-58af-4775-8318-5fddad5fe0b9">84f51be1-fc97-4931-8262-0e4219d1c6e4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="aa844f11-5b87-4cbd-b651-e9d24495afc4">de60a561-f3e5-4553-965b-1441a036dce5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e7ccab8b-67ae-45a0-bf7b-84bbf95018cd">374a15d0-f5d5-44f2-a6e5-1a3d7e06030a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6a750696-d957-4013-99cb-518b811ad981">ba223043-f165-4761-a40f-1e82dbcbed1e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e8748f1c-f1fd-44ed-ad81-3394ada57a5d">99803405-a846-4961-99c9-1f4048ee66a3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="56106a5d-05ea-4adb-a3b7-d0347ab1a547">c77951c9-18a1-43d0-880c-20a672ffe77f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d3e6be47-565b-49c0-9fc1-d0b26199bcb4">642b2af1-fac7-4548-b869-20b8d1b94657</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1d840236-7549-4453-a281-6c25793a8934">b2d846ea-6f5c-4f5d-bfd4-21f3eabab957</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1e71404c-40f0-45f2-85f0-72d3ed1890dd">b9cd8ddd-515d-4d5f-a989-23bb51fac37c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="dcae2d68-79f3-4832-93e8-49a628ea7849">7b9fdeee-fdc1-4a52-a1ae-248ef95c0aa2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5da44d2f-16ad-49e8-a0c5-394060f8590e">0215ffa7-d3d7-446e-92f0-29f5b2eefd61</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fdd0b1cf-2bd6-4458-989f-57f483b891c2">85afd931-7099-4d0a-9baf-2f0dbfa5d473</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5b3269ea-248a-4983-ad31-5ce4784e6306">a3d760a2-986e-4bfa-b87e-32810affc120</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2f6722f7-c70b-45e2-aa21-0c4e956ee23f">eefbb4a7-ad72-41e5-aa7f-32b25ea2b396</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3b1ff11b-2c1d-4bba-82d4-428ed14639e5">5346f541-c967-4af9-964f-32b282fa54bf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7b000fbd-2871-44f1-9090-94d205660cb8">0fe73171-b683-4f41-853e-3414dc7b5e59</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3b72d0f9-acc6-4e65-8dc3-e893aa8c69ea">a3c3138b-d3b0-4a71-b945-355ee2c1bdd9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="731b818c-73e3-470f-8fe6-ac8db55310fc">5ce80239-7cc4-4c82-8d1c-3b8ef46e3e3e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="99214fbe-ec3c-46ee-8449-d643075d3c03">e5592ca1-4de4-44ea-a795-3f27dc83baff</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="79ebf796-220a-4352-a266-65bcc5505f76">2e62fbfc-1283-416c-b2e3-43674a8a668b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8ff3ba17-2bea-4af8-af02-dff7947e1f1c">5efd6e6f-86ca-4a13-a61e-45bb694781bc</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1f87de65-d0d6-4bc7-aa24-0d4ee3932636">9bb8b441-1b70-4ac7-a146-460b37684c6f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d09848c2-4583-4ffc-8541-9b049c5d172c">ff0e9206-7695-48cd-a9f6-4879147b8570</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b1250ba4-3165-4958-99ee-cde9a0f8db5d">90c80938-a536-4aca-9c34-4973aebbf830</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d3ed6e4a-2bed-432e-b1cf-74f986fab85a">ac38dd2b-fa46-4d7c-8ee8-4a0e5f33b1c0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="daccde7c-e6f6-464e-85f1-42f110207b5f">c2d37cba-8f0e-4631-be92-500cc8d7eb3d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7f7a6af5-7cce-4df3-98a4-6bed6cf9ee5b">d1934614-a45d-4e1e-ae0f-5269599c04ce</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0f678100-9731-47db-865b-74e72e03d432">1b3c00c2-0bfa-4b64-8c61-6057ee85052e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c9755b3d-2f0f-435f-964e-bec94483406b">fac36a3e-cc03-48d2-906b-617e9aed01c6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="df535475-cf01-4f40-aaa3-251052922a15">c5818f93-503c-4b4d-99e4-65975e22b571</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0c25a58f-4502-4671-b78f-d0131414afc6">cf795229-2705-48c0-a227-6d016d31c381</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1c64ee73-fec2-4dc0-9b92-4b2517b798bf">b8ffcee3-4306-4585-b065-6da0c753df92</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="63d58d0d-5993-420c-a188-26b38cee3e21">395a662c-a45c-440b-9731-6f505e4f2238</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2357cf37-25c4-4589-90ca-fb5bbf7c5c9a">1a13a69f-6cdf-4982-9a2c-71bc108bf945</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9530fa71-e9dc-4c84-a985-f7d5b4fd2510">570e9173-3908-4d80-bbba-7928f0e3cae7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c1a16840-6292-4a58-abb3-6649ee9f8cf0">bc088c33-fd9b-4d30-81bf-7d7233fb6b1a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="502c2739-1d1e-4312-9944-fdf8596136b1">16f66309-e9b4-4b18-b191-807448ed7285</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ad415335-4986-4a70-8760-c3f2f373cf75">02222d21-1e42-4b83-b791-80b3172b6c2e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="83e311d5-d3f9-4ac0-b1cd-d4dd8cbff372">00162394-a69a-410a-9b02-8118a95ff26a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a5269e1d-19ff-4b90-a999-f535f1f9f722">3663d0b1-27fe-405f-b25c-83fa95e16b9f</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7d484622-694e-432d-8faa-e3a3244c0a66">81d69ac2-c80f-4d14-99e9-871d8bf56ba5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2752d6da-7834-4186-93a4-b782683b22ff">cf257778-dbf2-47f2-b2e2-8e5d4cbb7b5d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="219ed7a7-901d-4283-b6ca-86c0ef2e8cb5">31ea2013-4701-436a-8f12-9012f42fdb84</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="add253d1-73c4-43a1-b118-c49f14c2486e">b19ff32e-2dca-43d4-bab7-9bbc688f3ac9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6f2a6f75-b78a-456e-bab6-17f8d569e3d1">031a8473-0c0f-4b40-9d63-a00ad9d8b98b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1944cc86-cb0a-4586-998c-793f6cba7892">6ee5cb1d-bcec-4cb5-b0e6-a09cea67e556</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f1e20c83-d27f-42dd-9dfa-af71dfd263a8">bc7b96a9-8795-4df8-9e2e-a4a7bc005201</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="db617f06-c9b7-49f7-a667-20714828157c">ab493869-b70b-41a1-a4eb-a6372ca9d187</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b4ded7f1-93e3-46d6-8cdf-2ef47d04ca4e">a1fc08be-33c9-4997-bc9a-a72e2504649d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="dd78d6ee-8403-41e8-a887-a7c4b63ad545">d78180b4-b41c-4bd0-822d-a74a181b2139</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c78e42c8-4640-4ab2-bf5f-8062ac356753">22a04c16-ffbb-404f-aac2-a9bc41dfa73c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f938de36-a152-4fdd-9fcd-17a338011e72">a4f25ad2-8481-4ed5-95f6-abc8ded7e5e7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ecfdc4db-7d9d-4b2a-b84e-5d853ee99901">6a9f651c-7952-4539-8c4c-ad1558e906cb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="607a6508-cde2-4eee-a289-938f83eae934">7a29ac8b-932e-4ad9-b98d-b2b6da458cd4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="101a0dcf-16f9-4312-9a0f-2a75e02cd698">ca0dbca2-497e-45c3-8df0-b40cd6e88c4c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e1027ef9-cc5b-431a-b8e4-e32abece07b0">09c36a02-7ca4-45e1-9a07-b9e7230086e1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a0378b02-fd31-4815-9e3d-8f6ff9662e95">62149b2c-cda5-4216-a6bc-c30d7d23ec02</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e2c1bd0c-b2da-4f23-a35b-f5ba7ca333ce">ce8df54a-a636-4e12-af22-c59e6dba7141</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2f0b07a0-64f8-4f84-87ff-72b0124cf95a">437f6345-258b-47c9-8df9-ca6c38d9f58c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d8029307-5a5b-4f5a-9b70-549047240dc6">2730817e-79f6-4b60-812c-ce99f02b60ad</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="779130fa-aeaf-4399-ac96-03b662be3eed">36e3b39e-7c38-476b-b46b-cf68c4349847</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fa71face-8f51-49d8-abb9-87306d334fcf">4e3ccacc-1d97-42cd-a466-d17a693a5faa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="be2fde8a-6c89-4e78-9eef-5d51fd3729d0">7aab1f18-dde0-49e5-b09a-d20b58dd5ba5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a2dc288b-6437-4574-9732-f78f7aeef142">153de734-6421-435d-b919-d216bc95a2f9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="15bc644c-4099-4a43-b8a2-058daa27dd70">c59e3f05-515c-4ff6-a808-d6e7d57e0879</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f14a7c76-67a6-46af-9801-9396fc9c6a3a">278a0edd-448a-4382-8e1b-d88426d03f36</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ba764067-8368-4075-a7f3-fcdf82ed6ae4">85b8c779-1ffd-4ceb-9359-d942e45bf4c4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="61fee4e7-3dbf-499c-b415-185b00645eac">e552fb0f-635a-41f3-8486-da4b56e62453</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9facdf63-4eaf-49c0-984f-f26df26bb759">c18e44c8-0380-445e-9209-dbdf763c4d1b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7f8a8f69-d6d6-4945-a0d7-ccbf4fdcea65">2c958738-2370-4469-9b53-dc048687e3c2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9b00c9b9-355a-4f28-b964-21404623807b">5c3325e0-ff5d-4b3f-89a7-dd3921bbd5f5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="80a0a754-fa9c-4249-9f9a-59d425cf8103">3f7729e9-71c3-4ec5-87af-ddb460bfc050</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1ea59bb9-9fe3-46b8-a8c5-31a66aa27004">9e98d63c-7941-435c-8fc1-e09603ee515b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="61576ad8-d0ee-426b-b0ac-ddef71741c0b">1db2a9ba-426a-4608-995c-f2c4a06909d3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="77d092ba-2a0b-4203-93af-b0d17f4437bb">e3b911d3-d451-4bec-ab14-f3bb7443a7b0</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d8867e03-e052-40fa-8674-822e5545b78a">b1a087d7-b91c-414c-95d0-f768bac2b284</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e804880a-9e6d-4c45-a744-18a99c692bac">0e5659a8-3b4d-4115-8b58-fcc2e87d93d4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="49a9ad59-cb1d-4106-8763-b2187a009202">287e5814-ac40-48c1-9b31-ffcdbb395221</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.003</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>3</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7c470f10-b829-414a-99f0-0f19e4cc1b10">800e0fb8-1498-49db-b7a8-04b82d7e6d76</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1457568c-549c-438e-9101-bec4044471de">e85f33bf-c251-4121-b2ee-1911ac550a0b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="68aa88e1-0e61-45e7-bd1d-6aa81361e88b">9e10e4a0-dcb9-4ecf-8c62-1d5318d83bcc</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ecbbe983-00dc-4790-9d78-2b241f8107b3">d2121e86-57eb-4dce-b075-28ebbb2d26b7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a43ae4db-5b6f-4282-a436-4099d26fb8e8">b0a86d83-a4f9-4209-854a-4c06ecd06bab</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="714ea834-ba7f-4062-b84f-19c05994320d">c60de1aa-6c7f-419b-9190-5bceeb633a85</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7200a17a-7dc0-46f0-9182-b869c602afab">8f44df93-2704-4353-a195-5d9419f28b87</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f8524b8e-aab6-41a0-930d-2624ec6263ab">b3d584a4-bc83-4eca-9f8d-6fc44398907c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4d8041bf-f87d-42ff-a0f5-e4f18f3a8197">b806280b-245f-4187-adb7-957c0b63ba30</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="40d3fcb0-6be5-451e-9af4-c01384d18f3c">b6b2c81e-1b88-4ac8-ab52-a58b6404ef1b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8e783740-2f6e-4764-ba2e-ca576bd41773">a66e71b5-6a44-4473-9dd9-b715765a25aa</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a5d22cc9-939e-4312-a715-1e07f72c11b9">7c6c2bd0-1adf-4d29-a850-d090ef0516cd</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="18052cd4-5ac2-4fdb-b2f4-a5a37e18a972">74faa004-13af-4145-bad8-e393fad4cfbf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c1348f85-d5d1-41fe-9e16-76233b2c8ec2">9158925a-a900-440a-aab6-f59ef3b8633e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fc335b8e-ff41-47aa-b781-5cdabc8eb547">9571d7c8-848d-446f-a5f6-f80613f647f7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1087f13e-b738-40e8-a2bb-6d36b1dca723">13aff0c2-4ca5-48a2-a8ae-f8e57b801018</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:14.002</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>14</s>
+                <f>2</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f081e06d-5135-4507-9ce5-4e5ff256848a">14510134-7f69-428f-b625-af0d7e380877</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:43:13.977</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>43</m>
+                <s>13</s>
+                <f>977</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2a04bd03-d504-4f7e-8293-3d2b68305da7">354492a4-d8c4-4414-8c5d-68aa7d22a0eb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:38.228</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>38</s>
+                <f>228</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c1eb443a-241b-4dfb-8816-5651a9276664">c65c4311-46c6-43d5-86a1-ef63fef99bd1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:38.014</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>38</s>
+                <f>14</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5986552d-c213-4679-bb87-4edce4dfc7f1">0d384d86-96cd-4277-ac00-ea7af2b946ce</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:37.816</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>37</s>
+                <f>816</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0b03a257-b1b3-4b10-bffc-de558714fb12">576e8ec0-e055-400a-9c7e-af3b7b95f56e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:37.624</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>37</s>
+                <f>624</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b003f73d-7e17-473e-81cf-d14e1b7f328b">1c2bf4d8-2ac9-4643-8e5a-7fe2a5485f06</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:37.43</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>37</s>
+                <f>430</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="25d77644-9b6e-434a-9af6-33c09244b030">266451b2-57e1-455e-beae-a08fd4756435</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:37.225</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>37</s>
+                <f>225</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6d1fdf81-dc3a-4ed8-8b90-0fa0e468b5b3">590fe18a-10fb-4602-90e4-226a74fec4f8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:37.018</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>37</s>
+                <f>18</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c8d4a519-560c-41aa-86bf-a835c0e69ca7">2c37fb55-eeab-463e-9f9a-1d10eabf9e65</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:36.848</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>36</s>
+                <f>848</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0ab00eff-6e14-42fa-a705-250c63a5bf69">716aabf7-c516-484e-bd5e-c62a2c81208a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:36.692</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>36</s>
+                <f>692</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="05945bb6-8017-49bc-b0fc-58f7f34d84c5">623ecb77-e5b1-43fb-a1e8-8e596a5b7431</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:36.52</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>36</s>
+                <f>520</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9057b1f4-688c-48b5-b917-66f200b66677">5e507cb6-a977-402e-8876-204f299b01b6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:36.314</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>36</s>
+                <f>314</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f504405f-dfc2-4af1-90e5-b939b23084a2">73e5c4f2-e95c-41ee-9ce6-c9e08fae1e93</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:36.091</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>36</s>
+                <f>91</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a0ce9542-7ebe-4399-acd3-69307072e762">d466201e-90dd-41cf-a31b-1eae1e162ca6</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:35.88</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>35</s>
+                <f>880</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a690d69d-ea01-4b04-a3c8-1cedeaf73f65">c92bc382-a734-4bd9-a9ff-da1e3e3c05ff</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:35.664</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>35</s>
+                <f>664</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="52dbcbd2-6ea6-4f08-8826-69197efba8ae">9322c339-8200-42e7-8951-c09600b25961</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:35.476</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>35</s>
+                <f>476</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5ec4862d-36d0-4661-ad38-fb1ca992f95c">3283f2b9-4962-4af8-b09e-87b23baa8648</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:35.272</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>35</s>
+                <f>272</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8f836ca2-3bb3-4918-9ed4-755bfde0b76b">fdfd3ea5-1033-4da4-8a47-2e1c7c298582</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:35.059</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>35</s>
+                <f>59</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="5015ae3f-8d92-4a48-b44a-5749a84ec6d6">e76dac6a-d7de-42c4-b301-c2082ff56080</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:34.861</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>34</s>
+                <f>861</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ebc6d069-03cc-4c22-ad78-c0391e4c6c79">397a6058-778d-479b-abc4-772050e8be95</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:34.626</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>34</s>
+                <f>626</f>
+              </time>
+            </when>
+            <systolic>112</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="00d365e9-1104-431a-bd7a-c26b6a62d8b4">c24cc866-4788-465f-9de8-e00c3cf8060e</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:34.442</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>34</s>
+                <f>442</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7f02c18f-17af-4b49-a590-9a3811cdfa8b">d417c11e-40ab-4ec3-b3f3-63a0da618a73</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:34.248</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>34</s>
+                <f>248</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8d4f3e7b-4b1f-4ab3-9be1-3c99c71c39c3">3418539e-8301-4d03-ba41-e81020ee9e37</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:34.067</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>34</s>
+                <f>67</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fe650cbe-4080-4f72-a7d2-6f8b435d23e6">14c7392b-c520-47b9-a08c-81e9ef17bf54</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:33.89</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>33</s>
+                <f>890</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1263cfc8-0525-4567-93fd-a226842d6f4c">e35cb64d-8e29-478b-9660-db1d1a908b6b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:33.688</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>33</s>
+                <f>688</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="7574e6d1-502b-4823-b76f-76599b13db3e">66f840e3-5822-4874-86da-4c77d64991d7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:33.501</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>33</s>
+                <f>501</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8950aed4-940a-419b-9020-5143931531d3">b61192b5-2a89-42a5-b84e-d537d0953f6d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:33.3</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>33</s>
+                <f>300</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ee5ed923-379c-49aa-895f-505001ec042a">368acfc9-2ca5-4968-b2e2-d9c621ca0176</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:33.122</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>33</s>
+                <f>122</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="369cad10-bb68-4855-a71c-f758deecfcda">c2633048-c0fe-41dd-bb53-786d9dd6e0d9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:32.918</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>32</s>
+                <f>918</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9d9dfbe4-652b-40af-94ed-a1b55c5176c4">f41bc588-b5fa-4cf5-9c4b-4acac010f1bf</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:32.73</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>32</s>
+                <f>730</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="89b2fe81-3de1-488c-b04d-a48ea736edba">0ac4b46f-1b1d-4078-a457-dc251d2976e7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:32.529</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>32</s>
+                <f>529</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ecd53084-6c2f-4074-813a-66c4067bd617">3075bc40-acb1-45ff-a5f0-1f3354347471</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:32.332</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>32</s>
+                <f>332</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="34c0566a-eb09-4937-8313-67523fc11c97">75f90e06-594f-4a7d-ab42-ee94246c9730</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:32.132</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>32</s>
+                <f>132</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4adda3f3-28c8-4a11-93b8-71e8e1b85100">635be9cf-e6e1-48a5-85e3-e3aea18e8f59</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:31.972</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>31</s>
+                <f>972</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="90944ae0-4206-4007-912f-dc745e528a93">c0478d39-8fff-4e48-aaad-48ac73a2db24</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:31.806</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>31</s>
+                <f>806</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2f443182-8caa-4fa6-8d70-cb060ad2663b">826c7af5-5e1f-407f-95eb-dd27638f335c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:31.627</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>31</s>
+                <f>627</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="10519477-3eba-45df-b8ad-eb52d3f219f7">28c54192-6a8a-4029-9a98-fc710d6d0983</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:31.437</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>31</s>
+                <f>437</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8ab43c62-bbea-457f-b26b-9bd501e520c0">dcfeb7f9-5d4e-4c5f-b6a3-0c8e1e75271d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:31.265</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>31</s>
+                <f>265</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="afa44018-eb04-4347-ab1e-5e20d2e1dcbc">e1002346-1ee2-4779-a54c-bf2504ae4ebe</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:31.042</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>31</s>
+                <f>42</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="024c4fb8-530e-4928-8f32-90228acb2066">f7c76f77-e066-4993-b0a5-bd1477521735</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:30.876</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>30</s>
+                <f>876</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="32e618c7-cc28-42a9-9673-62d67fe91f15">012a9cab-65b2-4654-b116-0b1411d5db03</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:30.688</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>30</s>
+                <f>688</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="225a66e7-493c-4861-ba25-e0353275d9cc">a299d933-5c1f-4b6a-9e53-333dfaff35cb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:30.507</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>30</s>
+                <f>507</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="28cf4a3d-f7eb-4965-9d3e-6d4e1b891173">c93689d5-163a-42cc-9efd-27f22874987a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:30.293</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>30</s>
+                <f>293</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="a8630667-3c90-44e3-a6fb-31b693b16a25">0b68d06a-749f-4d78-8bc8-02219398db01</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:30.1</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>30</s>
+                <f>100</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4ae4c390-675f-4637-90c5-cbc6fb69d170">9695fbf3-ddc6-4a16-b339-24ecc4617ba5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:29.903</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>29</s>
+                <f>903</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6b1332c5-451f-4a05-a54a-f0747fe88d2b">af7c3eac-7494-4085-8a48-f9562c587f70</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:29.73</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>29</s>
+                <f>730</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="78b78a09-691f-49fb-a214-c5c2dc5158f7">ba18f019-3c31-4a12-9d99-900050db09c1</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:29.541</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>29</s>
+                <f>541</f>
+              </time>
+            </when>
+            <systolic>127</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8dd14f40-f806-4b85-842c-e828f99d84f3">20e31efc-daa4-43d7-9d2e-d16eaa402e8a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:29.353</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>29</s>
+                <f>353</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e166161f-2295-456d-a5e0-1e1b29f69f88">783f1e34-5a7c-4db3-925c-3cba8ae01961</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:29.128</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>29</s>
+                <f>128</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d9c91ac3-effa-401b-8979-c074dd246d33">f0a36c60-e397-43c6-85b4-a9545ef639a2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:28.95</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>28</s>
+                <f>950</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cb4995c2-e516-43df-ae27-fdc415104380">1c11c629-e15c-4d76-86a2-559ea01c8a0b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:28.746</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>28</s>
+                <f>746</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>83</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="165cb8cb-8c35-4ff3-851f-568496ca97e8">ce456e6d-3f92-47dc-8636-678c2e70791b</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:28.574</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>28</s>
+                <f>574</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="3205ca2c-2008-4084-a948-99c713708814">c2da6be1-aa78-423c-adf4-dc854462e4c9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:28.352</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>28</s>
+                <f>352</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="fbb7c6c0-a791-478c-8517-04528c0db54f">bc31ddb2-bda9-4f5a-b231-1b5361827036</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:28.153</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>28</s>
+                <f>153</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="86ec6fd0-1c5b-4eca-af9b-b08162d799c1">be1c0694-5f5d-47a6-9227-9f8c59dab286</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:27.969</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>27</s>
+                <f>969</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="c15fd9f6-7f7f-42ba-abfe-5a9d0c0a6534">b87d215b-9904-45c4-8bfe-ea8feae30449</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:27.771</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>27</s>
+                <f>771</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="02e98fbe-76bd-4761-a4b7-794646fe5f50">12c3455a-b128-4f62-bcaf-1a7906653250</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:27.594</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>27</s>
+                <f>594</f>
+              </time>
+            </when>
+            <systolic>124</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="05eb174a-727b-45c6-aaa6-6ebcc6e1a911">b46514b9-49af-439e-83f7-98c1e3fbeed3</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:27.413</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>27</s>
+                <f>413</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6f8ac174-8d32-4a0c-a063-a835a3205bdb">c3093d42-690d-4bd6-9917-9ce4099e03c7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:27.199</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>27</s>
+                <f>199</f>
+              </time>
+            </when>
+            <systolic>119</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ac007881-efcc-405f-ada9-e78626ef2521">adc5d8bd-902a-4492-9a8f-7b16297973b8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:27.013</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>27</s>
+                <f>13</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cb5e092a-1a9c-4a43-b9f1-297534141ab3">3937d1da-c068-405e-9ff0-d229775fa2c9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:26.834</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>26</s>
+                <f>834</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>82</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b6682775-8158-440b-abf9-9fefc7ac37cc">a209a7af-30d0-43ab-bdf3-9a0d89d5f7a2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:26.631</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>26</s>
+                <f>631</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="84846ae2-b5ad-48a0-a093-ccbde411abc5">874b5aeb-8960-4171-8b4b-2a65e597c54c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:26.453</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>26</s>
+                <f>453</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="734c7d57-e4a2-46bf-a15c-121a5ba10717">10597bca-0da8-4926-bd1f-07c58fe3591a</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:26.266</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>26</s>
+                <f>266</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8349dbe3-6460-43c7-9bd5-2e41b94cbbe7">9838b229-8e17-4a20-a17e-2563ff476f71</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:26.071</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>26</s>
+                <f>71</f>
+              </time>
+            </when>
+            <systolic>128</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d019a866-a88f-49ef-8d3a-95ae83a26523">aad6685c-32e1-47b3-afe1-0bc0674f6268</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:25.904</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>25</s>
+                <f>904</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="6cc1063b-fa3b-4fe0-a7e4-f8cdd43e6875">97a6897a-d196-411c-a9cb-080007cb7e58</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:25.688</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>25</s>
+                <f>688</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0149eeb5-67d0-4116-b2a2-976288d03731">ca12568e-892f-4c50-abe3-47dc3c685d31</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:25.533</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>25</s>
+                <f>533</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cef9e96f-8eb2-4e1d-ae05-53124f1a381e">16221b90-ba65-49d7-9b93-8cf46b451de7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:25.339</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>25</s>
+                <f>339</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9009468d-9fc5-40c6-b5b5-68653781f7df">f8e386cc-3401-4a41-acf4-c0c785d5e4ea</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:25.153</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>25</s>
+                <f>153</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>84</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="e87375e0-81f0-4bcf-a704-a60c0f5f0ca1">54c3092a-c769-4a10-a8a3-f068d3752881</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:24.979</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>24</s>
+                <f>979</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9b3a9e88-7356-4f83-86a6-ed4b4774265f">ca4b3bcf-a4a7-45f4-828b-2856f814ee80</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:24.798</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>24</s>
+                <f>798</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="bbd646de-d11c-4b54-8397-b3bd3f9e1ae6">b9b60972-ace4-49cd-b0c4-b7e68bbca72c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:24.619</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>24</s>
+                <f>619</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="59a9fdbc-5b5f-4697-bc03-442d09968615">a6b505bb-1f35-4fa0-9595-811b456cbb91</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:24.44</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>24</s>
+                <f>440</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4aefe730-963e-41bd-97d3-33eff14ae217">fa792001-47ac-4d0e-9027-37b1225da673</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:24.238</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>24</s>
+                <f>238</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>75</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ba9e5a99-c278-4347-92b9-837734605fb4">83bac34b-41cc-4c11-b6b6-8f6092684913</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:24.058</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>24</s>
+                <f>58</f>
+              </time>
+            </when>
+            <systolic>111</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="575d8b2e-6ccd-4cbc-9917-70546080e1d0">b18359d9-726a-4e67-be30-3eb26597b2b5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:23.871</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>23</s>
+                <f>871</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d0bea6b2-7389-4c52-8515-f7a6f1fcfdcb">d2317ef1-1daa-458f-a05f-6546cc888203</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:23.688</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>23</s>
+                <f>688</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>86</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="faa7e53c-d8b7-4eed-8e37-7e4fffc0554e">defb0f11-aa25-4e28-97e8-0df118ddd4bb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:23.487</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>23</s>
+                <f>487</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="857a543c-cc81-46a3-94e5-72bd8a5c5c6f">2461b54e-a33b-4c96-8ab7-a1efb0bfcfa9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:23.313</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>23</s>
+                <f>313</f>
+              </time>
+            </when>
+            <systolic>125</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cbcf2046-577a-440f-9c8f-503f5b08761b">fc1babf0-e3e2-46bd-b3ae-327dcb881c1c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:23.128</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>23</s>
+                <f>128</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>88</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+    </group>
+  </wc:info>
+</response>

--- a/Microsoft.HealthVault.UnitTest/Samples/ThingsPagedResult3.xml
+++ b/Microsoft.HealthVault.UnitTest/Samples/ThingsPagedResult3.xml
@@ -1,0 +1,625 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<response>
+  <status>
+    <code>0</code>
+  </status>
+  <wc:info xmlns:wc="urn:com.microsoft.wc.methods.response.GetThings3">
+    <group>
+      <thing>
+        <thing-id version-stamp="55d620f9-99ea-4f81-b186-ab2a04522061">f5f2c6f0-6924-4744-9338-8e3d81c31259</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:22.942</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>22</s>
+                <f>942</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="b004a256-2e03-4cb6-8372-fad379d3c7bb">990cc5b1-933a-410a-92f2-2669343f9bd8</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:22.767</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>22</s>
+                <f>767</f>
+              </time>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="4a75442f-4867-44f1-ae4d-a0451c1d4131">5cd0581c-d160-4f6a-b64d-2210efb6f4a9</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:22.597</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>22</s>
+                <f>597</f>
+              </time>
+            </when>
+            <systolic>120</systolic>
+            <diastolic>85</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="d29993c4-22a4-4952-9a2e-71c74f1a3946">79fc5081-2b3e-4245-ac28-821f4bfbe9e2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:22.41</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>22</s>
+                <f>410</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>77</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="439b859a-b0ca-4190-84cc-d481314be10d">902e028f-bf04-4e24-9faf-69f4e79f8195</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:22.216</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>22</s>
+                <f>216</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>74</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="1e387f67-c94d-43f0-a55f-57bc17935343">b1ad799a-7984-431b-8ae0-ba3dbb5380c7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:22.013</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>22</s>
+                <f>13</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="af0e5b43-788f-42ab-9030-68ec30ea3dcb">0f73d0d4-164e-47ce-8944-1a377c3c2d5c</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:21.831</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>21</s>
+                <f>831</f>
+              </time>
+            </when>
+            <systolic>118</systolic>
+            <diastolic>87</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2beb3260-b233-4eaa-a570-01b763127656">d97cd429-be2e-4c3b-916b-072e285a5902</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:21.638</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>21</s>
+                <f>638</f>
+              </time>
+            </when>
+            <systolic>121</systolic>
+            <diastolic>72</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="cac41aa2-ac33-4339-a886-6bed9285fda2">fc0f81e2-0c4c-4237-add6-9ec9da5105f4</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:21.478</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>21</s>
+                <f>478</f>
+              </time>
+            </when>
+            <systolic>129</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="488818c6-f0ad-4a71-a739-cd63369a1070">d3a528c0-0036-4108-9a25-60b6cf29fec7</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:21.31</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>21</s>
+                <f>310</f>
+              </time>
+            </when>
+            <systolic>114</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="349bd092-ad55-4235-8f3d-cd652647810c">fa977fd6-b488-44df-b971-0d11439cd61d</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:21.159</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>21</s>
+                <f>159</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>79</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="62398329-9265-4f48-8926-82ed46745a6f">674321a3-c22b-4afd-b687-e39c4bc499cc</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:20.97</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>20</s>
+                <f>970</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="f77b81bd-fd31-4c28-93f4-e1b20fe40a98">912bfba0-9acc-4d39-b346-33abfacfb201</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:20.814</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>20</s>
+                <f>814</f>
+              </time>
+            </when>
+            <systolic>113</systolic>
+            <diastolic>76</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="36e9b051-7bd1-4f51-9efa-af76f51acfe6">3e414c0c-4c1a-47bd-bd4c-1a33534dbdeb</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:20.629</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>20</s>
+                <f>629</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>81</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8a6cb0c4-5fb0-4600-bcce-550ad70c0fa7">0b1ed5a4-3456-453e-91f7-6d22a1d7bead</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:20.407</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>20</s>
+                <f>407</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="86dd5ee1-b499-4095-9650-10893d2ea0d4">8f9ae913-4bdb-44a3-8bd6-8fee506ed5c2</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:20.231</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>20</s>
+                <f>231</f>
+              </time>
+            </when>
+            <systolic>116</systolic>
+            <diastolic>89</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="07a73e5e-ef62-4438-85d6-f94b30e7563c">3ee73717-661e-4f31-9ec9-867676cd9e08</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:20.048</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>20</s>
+                <f>48</f>
+              </time>
+            </when>
+            <systolic>122</systolic>
+            <diastolic>71</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="09cb8e84-2757-4ced-8a29-47d43a2b8b87">4a449d31-a1ed-4035-801c-7e36a9b75145</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:19.853</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>19</s>
+                <f>853</f>
+              </time>
+            </when>
+            <systolic>115</systolic>
+            <diastolic>78</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="0acfd944-e550-4e70-a430-a6c591208f1d">f2f09439-2eca-4ca0-a061-efa39c693462</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:19.668</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>19</s>
+                <f>668</f>
+              </time>
+            </when>
+            <systolic>126</systolic>
+            <diastolic>80</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="ed1879a3-13d9-40bc-95d8-e873721c1c63">05a5018a-20ae-4eec-bab3-9c7b1e48a420</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-23T12:41:19.35</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>41</m>
+                <s>19</s>
+                <f>350</f>
+              </time>
+            </when>
+            <systolic>123</systolic>
+            <diastolic>73</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="9b379300-bb6f-4d46-8ff0-328a04513f30">295eda72-9b30-4811-82ab-33d34b979705</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-10T00:00:00</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>10</d>
+              </date>
+            </when>
+            <systolic>110</systolic>
+            <diastolic>29</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="2a0e1f1a-3a61-4446-8d28-4ffbe6c9350f">a1a6ab8a-7169-459b-98e1-9d6d880098b5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-05-09T11:00:44.759</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>5</m>
+                <d>9</d>
+              </date>
+              <time>
+                <h>11</h>
+                <m>0</m>
+                <s>44</s>
+                <f>759</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+      <thing>
+        <thing-id version-stamp="8ca1fe29-ee44-4187-9255-2cef77f965ee">09883e46-7bfd-4af4-9026-0b5b9fbd77a5</thing-id>
+        <type-id name="Blood pressure">ca3c57f4-f4c1-4e15-be67-0a3caf5414ed</type-id>
+        <thing-state>Active</thing-state>
+        <flags>0</flags>
+        <eff-date>2017-03-23T12:39:48.107</eff-date>
+        <data-xml>
+          <blood-pressure>
+            <when>
+              <date>
+                <y>2017</y>
+                <m>3</m>
+                <d>23</d>
+              </date>
+              <time>
+                <h>12</h>
+                <m>39</m>
+                <s>48</s>
+                <f>107</f>
+              </time>
+            </when>
+            <systolic>117</systolic>
+            <diastolic>70</diastolic>
+          </blood-pressure>
+          <common />
+        </data-xml>
+      </thing>
+    </group>
+  </wc:info>
+</response>

--- a/Microsoft.HealthVault/Clients/Deserializers/ThingDeserializer.cs
+++ b/Microsoft.HealthVault/Clients/Deserializers/ThingDeserializer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.HealthVault.Clients.Deserializers
 
         public ThingDeserializer(IHealthVaultConnection connection)
         {
-            connection = connection;
+            _connection = connection;
         }
 
         public IReadOnlyCollection<ThingCollection> Deserialize(

--- a/Microsoft.HealthVault/Connection/HealthVaultConnectionBase.cs
+++ b/Microsoft.HealthVault/Connection/HealthVaultConnectionBase.cs
@@ -139,7 +139,7 @@ namespace Microsoft.HealthVault.Connection
             HealthServiceResponseData responseData = null;
             try
             {
-                responseData = await SendRequestAsync(requestXml, correlationId);
+                responseData = await SendRequestAsync(requestXml, correlationId).ConfigureAwait(false);
             }
             catch (HealthServiceAuthenticatedSessionTokenExpiredException)
             {

--- a/Microsoft.HealthVault/Thing/ThingCollection.cs
+++ b/Microsoft.HealthVault/Thing/ThingCollection.cs
@@ -1049,9 +1049,7 @@ namespace Microsoft.HealthVault.Thing
             List<ThingKey> partialThings = new List<ThingKey>();
             for (
                 int partialThingIndex = index;
-                (partialThings.Count < MaxResultsPerRequest ||
-                 MaxResultsPerRequest == int.MinValue) &&
-                partialThingIndex < _abstractResults.Count;
+                (partialThings.Count < MaxResultsPerRequest || MaxResultsPerRequest == int.MinValue) && partialThingIndex < _abstractResults.Count;
                 ++partialThingIndex)
             {
                 var key = _abstractResults[partialThingIndex] as ThingKey;

--- a/Microsoft.HealthVault/Transport/HealthWebRequestClient.cs
+++ b/Microsoft.HealthVault/Transport/HealthWebRequestClient.cs
@@ -90,7 +90,7 @@ namespace Microsoft.HealthVault.Transport
 
             message.Content = content;
 
-            return await SendAsync(message, token);
+            return await SendAsync(message, token).ConfigureAwait(false);
         }
 
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage message, CancellationToken token, bool throwExceptionOnFailure = true)

--- a/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml
+++ b/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml
@@ -6,9 +6,12 @@
 
     <StackLayout>
         <Button Clicked="Connect_OnClicked" Text="Connect" />
-        <Button Clicked="SetBP_OnClicked" Text="Add BP" />
-        <Button Clicked="GetBP_OnClicked" Text="Get BP" />
-        <Button Clicked="MultiQuery_OnClicked" Text="Get Things Multi-Query" />
+        <StackLayout x:Name="ConnectedButtons" IsVisible="False">
+            <Button Clicked="SetBP_OnClicked" Text="Add BP" />
+            <Button Clicked="Add100BPs_OnClicked" Text="Add 100 BPs" />
+            <Button Clicked="GetBP_OnClicked" Text="Get BP" />
+            <Button Clicked="MultiQuery_OnClicked" Text="Get Things Multi-Query" />
+        </StackLayout>
         <Label x:Name="OutputLabel" />
     </StackLayout>
 </ContentPage>

--- a/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml.cs
+++ b/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml.cs
@@ -6,6 +6,7 @@ using Microsoft.HealthVault.Clients;
 using Microsoft.HealthVault.Configuration;
 using Microsoft.HealthVault.ItemTypes;
 using Microsoft.HealthVault.Person;
+using Microsoft.HealthVault.Record;
 using Microsoft.HealthVault.Thing;
 using Xamarin.Forms;
 
@@ -34,6 +35,7 @@ namespace SandboxXamarinForms
             await _connection.AuthenticateAsync();
 
             _thingClient = _connection.CreateThingClient();
+            this.ConnectedButtons.IsVisible = true;
 
             OutputLabel.Text = "Connected.";
         }
@@ -55,6 +57,32 @@ namespace SandboxXamarinForms
             OutputLabel.Text = "Added blood pressure";
         }
 
+        private async void Add100BPs_OnClicked(object sender, EventArgs e)
+        {
+            OutputLabel.Text = "Adding 100 blood pressures...";
+
+            PersonInfo personInfo = await _connection.GetPersonInfoAsync();
+            HealthRecordInfo recordInfo = personInfo.SelectedRecord;
+            IThingClient thingClient = _connection.CreateThingClient();
+
+            var random = new Random();
+
+            var pressures = new List<BloodPressure>();
+            for (int i = 0; i < 100; i++)
+            {
+                pressures.Add(new BloodPressure(
+                    new HealthServiceDateTime(DateTime.Now),
+                    random.Next(110, 130),
+                    random.Next(70, 90)));
+            }
+
+            await thingClient.CreateNewThingsAsync(
+                recordInfo.Id,
+                pressures);
+
+            OutputLabel.Text = "Done adding blood pressures.";
+        }
+
         private async void GetBP_OnClicked(object sender, EventArgs e)
         {
             // use our thing client to get all things of type blood pressure
@@ -67,7 +95,7 @@ namespace SandboxXamarinForms
             }
             else
             {
-                OutputLabel.Text = firstBloodPressure.Systolic + "/" + firstBloodPressure.Diastolic;
+                OutputLabel.Text = firstBloodPressure.Systolic + "/" + firstBloodPressure.Diastolic + ", " + bloodPressures.Count + " total";
             }
         }
 


### PR DESCRIPTION
There were a couple problems: First there was a bug on ThingDeserializer where the connection passed in wasn't getting saved. Second, there were a couple of missing .ConfigureAwait(false) statements, meaning that the synchronous access in ThingCollection was causing a deadlock.
Also added a unit test to validate this scenario.