### PR TITLE
Style Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,160 @@
+# editorconfig.org
+
+# top-most EditorConfig file
 root = true
 
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
 indent_style = space
 indent_size = 4
 
+[project.json]
+indent_size = 2
+
+# C# files
 [*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_within_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# avoid this. unless absolutely necessary
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion
 dotnet_style_qualification_for_method = false:suggestion
 dotnet_style_qualification_for_event = false:suggestion
+
+# only use var when it's obvious what the variable type is
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# use language keywords instead of BCL types
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case 
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+
+# Code style defaults
+dotnet_sort_system_directives_first = true
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_properties = true:none
+csharp_style_expression_bodied_indexers = true:none
+csharp_style_expression_bodied_accessors = true:none
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml build files
+[*.builds]
+indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/Microsoft.HealthVault.Client.Android/SignInActivity.cs
+++ b/Microsoft.HealthVault.Client.Android/SignInActivity.cs
@@ -94,8 +94,8 @@ namespace Microsoft.HealthVault.Client.Platform.Android
 
             public SignInWebViewClient(SignInActivity activity, string endUrl)
             {
-                activity = activity;
-                endUrl = endUrl;
+                _activity = activity;
+                _endUrl = endUrl;
             }
 
             public override void OnPageFinished(WebView view, string url)

--- a/Microsoft.HealthVault.Client.Bait/HealthVaultConnectionFactory.cs
+++ b/Microsoft.HealthVault.Client.Bait/HealthVaultConnectionFactory.cs
@@ -9,8 +9,6 @@
 using System;
 using Microsoft.HealthVault.Client.Core;
 
-using System;
-
 namespace Microsoft.HealthVault.Client
 {
     public class HealthVaultConnectionFactory

--- a/Microsoft.HealthVault/ItemTypes/ApproximateDateTime.cs
+++ b/Microsoft.HealthVault/ItemTypes/ApproximateDateTime.cs
@@ -56,7 +56,7 @@ namespace Microsoft.HealthVault.ItemTypes
         {
             Validator.ThrowIfArgumentNull(approximateDate, nameof(approximateDate), Resources.ApproximateDateTimeDateNull);
 
-            approximateDate = approximateDate;
+            _approximateDate = approximateDate;
             _approximateTime = null;
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.HealthVault.ItemTypes
             ApproximateTime approximateTime)
             : this(approximateDate)
         {
-            approximateTime = approximateTime;
+            _approximateTime = approximateTime;
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Microsoft.HealthVault.ItemTypes
             CodableValue timeZone)
             : this(approximateDate, approximateTime)
         {
-            timeZone = timeZone;
+            _timeZone = timeZone;
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace Microsoft.HealthVault.ItemTypes
         public ApproximateDateTime(string description)
         {
             Validator.ThrowIfStringNullOrEmpty(description, "description");
-            description = description;
+            _description = description;
             _approximateDate = null;
         }
 

--- a/Microsoft.HealthVault/ItemTypes/CarePlanGoalGroup.cs
+++ b/Microsoft.HealthVault/ItemTypes/CarePlanGoalGroup.cs
@@ -69,7 +69,7 @@ namespace Microsoft.HealthVault.ItemTypes
                 throw new ArgumentException(Resources.CarePlanGoalGroupGroupsEmpty, nameof(goals));
             }
 
-            goals = goals;
+            _goals = goals;
         }
 
         /// <summary>

--- a/Microsoft.HealthVault/ItemTypes/GroupMembershipType.cs
+++ b/Microsoft.HealthVault/ItemTypes/GroupMembershipType.cs
@@ -104,7 +104,7 @@ namespace Microsoft.HealthVault.ItemTypes
 
             CodableValue name = new CodableValue();
             name.ParseXml(navigator.SelectSingleNode("name"));
-            name = name;
+            _name = name;
             _value = navigator.SelectSingleNode("value").Value;
         }
 

--- a/Microsoft.HealthVault/ItemTypes/HeartRateZone.cs
+++ b/Microsoft.HealthVault/ItemTypes/HeartRateZone.cs
@@ -53,7 +53,7 @@ namespace Microsoft.HealthVault.ItemTypes
             int lowerBoundaryHeartRate,
             int upperBoundaryHeartRate)
         {
-            name = name;
+            _name = name;
             _lowAbsolute = lowerBoundaryHeartRate;
             _upperAbsolute = upperBoundaryHeartRate;
         }
@@ -82,7 +82,7 @@ namespace Microsoft.HealthVault.ItemTypes
             double lowerBoundaryPercentage,
             double upperBoundaryPercentage)
         {
-            name = name;
+            _name = name;
             _lowRelative = lowerBoundaryPercentage;
             _upperRelative = upperBoundaryPercentage;
         }
@@ -106,7 +106,7 @@ namespace Microsoft.HealthVault.ItemTypes
             string name = navigator.GetAttribute("name", string.Empty);
             if (name.Length != 0)
             {
-                name = name;
+                _name = name;
             }
 
             XPathNavigator lowNav =

--- a/Microsoft.HealthVault/ItemTypes/HeartRateZoneGroup.cs
+++ b/Microsoft.HealthVault/ItemTypes/HeartRateZoneGroup.cs
@@ -95,7 +95,7 @@ namespace Microsoft.HealthVault.ItemTypes
             string name = navigator.GetAttribute("name", string.Empty);
             if (name.Length != 0)
             {
-                name = name;
+                _name = name;
             }
 
             XPathNodeIterator zoneIterator =


### PR DESCRIPTION
- Updating the .editorconfig file with the settings from CoreFX, with an adjustment
- Fixing name conversion stragglers where constructors were assigning their input to itself instead of the class' fields.

#54410
#55403