### PR TITLE
HealthServiceDateTime null ref fix

### DIFF
--- a/Microsoft.HealthVault.UnitTest/ItemTypes/HealthServiceDateTimeTests.cs
+++ b/Microsoft.HealthVault.UnitTest/ItemTypes/HealthServiceDateTimeTests.cs
@@ -44,6 +44,17 @@ namespace Microsoft.HealthVault.UnitTest.ItemTypes
         }
 
         [TestMethod]
+        public void WhenSameDatePassedToEqualsWithLocalDateTime_ThenTrueReturned()
+        {
+            HealthServiceDate date = new HealthServiceDate(2017, 1, 12);
+
+            HealthServiceDateTime healthServiceDateTime = new HealthServiceDateTime(date);
+            LocalDateTime localDateTime = new LocalDateTime(2017, 1, 12, 2, 40, 17);
+
+            Assert.IsTrue(healthServiceDateTime.Equals(localDateTime), "The equals should return true.");
+        }
+
+        [TestMethod]
         public void WhenDifferentDatePassedToEquals_ThenFalseReturned()
         {
             HealthServiceDateTime dateTime1 = new HealthServiceDateTime(new LocalDateTime(2017, 5, 18, 5, 28, 20));

--- a/Microsoft.HealthVault/ItemTypes/HealthServiceDateTime.cs
+++ b/Microsoft.HealthVault/ItemTypes/HealthServiceDateTime.cs
@@ -501,6 +501,11 @@ namespace Microsoft.HealthVault.ItemTypes
                 return -1;
             }
 
+            if (Time == null)
+            {
+                return 0;
+            }
+
             return Time.CompareTo(other.TimeOfDay);
         }
 


### PR DESCRIPTION
Fixed null reference when creating a HealthServiceDateTime from a HealthServiceDate and comparing it to a LocalDateTime with the same year, month, day.