### PR TITLE
Fix AuthorizeAdditionalRecordsAsync

### DIFF
--- a/Microsoft.HealthVault.Client.Core/HealthVaultSodaConnection.cs
+++ b/Microsoft.HealthVault.Client.Core/HealthVaultSodaConnection.cs
@@ -110,8 +110,7 @@ namespace Microsoft.HealthVault.Client
                 }
 
                 // First run through shell with web browser to get additional records authorized.
-                var masterApplicationId = Configuration.MasterApplicationId;
-                await _shellAuthService.AuthorizeAdditionalRecordsAsync(ServiceInstance.ShellUrl, masterApplicationId).ConfigureAwait(false);
+                await _shellAuthService.AuthorizeAdditionalRecordsAsync(ServiceInstance.ShellUrl, ApplicationCreationInfo.AppInstanceId).ConfigureAwait(false);
 
                 // Update the person info to add the newly authorized records.
                 await GetAndSavePersonInfoAsync().ConfigureAwait(false);

--- a/Microsoft.HealthVault.Client.Core/IShellAuthService.cs
+++ b/Microsoft.HealthVault.Client.Core/IShellAuthService.cs
@@ -15,6 +15,6 @@ namespace Microsoft.HealthVault.Client
     {
         Task<string> ProvisionApplicationAsync(Uri shellUrl, Guid masterAppId, string appCreationToken, string appInstanceId);
 
-        Task AuthorizeAdditionalRecordsAsync(Uri shellUrl, Guid masterAppId);
+        Task AuthorizeAdditionalRecordsAsync(Uri shellUrl, Guid appInstanceId);
     }
 }

--- a/Microsoft.HealthVault.Client.Core/ShellAuthService.cs
+++ b/Microsoft.HealthVault.Client.Core/ShellAuthService.cs
@@ -51,7 +51,7 @@ namespace Microsoft.HealthVault.Client
                 query += "&aib=true";
             }
 
-            Uri successUri = await AuthenticateInBrowserAsync(shellUrl, query).ConfigureAwait(false);
+            Uri successUri = await AuthenticateInBrowserAsync(shellUrl, query, HealthVaultConstants.ShellRedirectTargets.CreateApplication).ConfigureAwait(false);
             string environmentInstanceId = ParseEnvironmentInstanceIdFromUri(successUri.ToString());
             if (environmentInstanceId == null)
             {
@@ -61,22 +61,22 @@ namespace Microsoft.HealthVault.Client
             return environmentInstanceId;
         }
 
-        public async Task AuthorizeAdditionalRecordsAsync(Uri shellUrl, Guid masterAppId)
+        public async Task AuthorizeAdditionalRecordsAsync(Uri shellUrl, Guid appInstanceId)
         {
             if (shellUrl == null)
             {
                 throw new ArgumentNullException(nameof(shellUrl));
             }
 
-            string query = $"?appid={masterAppId}&ismra={MraString}";
+            string query = $"appid={appInstanceId}&ismra={MraString}&mobile=true";
 
-            await AuthenticateInBrowserAsync(shellUrl, query).ConfigureAwait(false);
+            await AuthenticateInBrowserAsync(shellUrl, query, HealthVaultConstants.ShellRedirectTargets.AppAuth).ConfigureAwait(false);
         }
 
-        private async Task<Uri> AuthenticateInBrowserAsync(Uri shellUrl, string query)
+        private async Task<Uri> AuthenticateInBrowserAsync(Uri shellUrl, string query, string target)
         {
             UriBuilder provisionBuilder = GetShellUriBuilder(shellUrl);
-            string fullQuery = $"target={HealthVaultConstants.ShellRedirectTargets.CreateApplication}&targetqs=" + Uri.EscapeDataString(query);
+            string fullQuery = $"target={target}&targetqs=" + Uri.EscapeDataString(query);
             provisionBuilder.Query = fullQuery;
             Uri provisionUIUrl = provisionBuilder.Uri;
 

--- a/Microsoft.HealthVault.UnitTest/HealthVaultSodaConnectionTests.cs
+++ b/Microsoft.HealthVault.UnitTest/HealthVaultSodaConnectionTests.cs
@@ -196,7 +196,7 @@ namespace Microsoft.HealthVault.UnitTest
             await healthVaultSodaConnection.AuthorizeAdditionalRecordsAsync();
 
             await _subShellAuthService.Received()
-                .AuthorizeAdditionalRecordsAsync(new Uri("https://account.healthvault-ppe.com/"), s_masterApplicationId);
+                .AuthorizeAdditionalRecordsAsync(new Uri("https://account.healthvault-ppe.com/"), new Guid(ApplicationInstanceId));
 
             await _subLocalObjectStore.Received()
                 .WriteAsync(HealthVaultSodaConnection.PersonInfoKey, Arg.Any<object>());

--- a/Microsoft.HealthVault.UnitTest/ShellAuthServiceTests.cs
+++ b/Microsoft.HealthVault.UnitTest/ShellAuthServiceTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.HealthVault.UnitTest
         private static readonly Uri s_shellUrl = new Uri("https://contoso.com/shell");
 
         private static readonly Guid s_masterApplicationId = new Guid("30945bac-d221-4f89-8197-6983a390066d");
+        private static readonly Guid s_appInstanceId = new Guid(ApplicationInstanceId);
 
         [TestInitialize]
         public void TestInitialize()
@@ -62,7 +63,7 @@ namespace Microsoft.HealthVault.UnitTest
                 .Returns(successUri);
 
             ShellAuthService service = CreateService();
-            await service.AuthorizeAdditionalRecordsAsync(s_shellUrl, s_masterApplicationId);
+            await service.AuthorizeAdditionalRecordsAsync(s_shellUrl, s_appInstanceId);
 
             await _subBrowserAuthBroker
                 .Received()
@@ -126,7 +127,7 @@ namespace Microsoft.HealthVault.UnitTest
             }
 
             Assert.IsFalse(urlString.Contains(Uri.EscapeDataString("aib=")));
-            Assert.IsTrue(urlString.Contains(Uri.EscapeDataString("appid=" + s_masterApplicationId)));
+            Assert.IsTrue(urlString.Contains(Uri.EscapeDataString("appid=" + s_appInstanceId)));
 
             return true;
         }

--- a/Microsoft.HealthVault/HealthVaultConstants.cs
+++ b/Microsoft.HealthVault/HealthVaultConstants.cs
@@ -39,6 +39,7 @@ namespace Microsoft.HealthVault
         internal static class ShellRedirectTargets
         {
             internal const string Auth = "AUTH";
+            internal const string AppAuth = "APPAUTH";
             internal const string AppSignOut = "APPSIGNOUT";
             internal const string CreateApplication = "CREATEAPPLICATION";
         }

--- a/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml
+++ b/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml
@@ -13,6 +13,7 @@
             <Button Clicked="MultiQuery_OnClicked" Text="Get Things Multi-Query" />
             <Button Clicked="GetItemTypeDef_OnClicked" Text="Get Item Type Definition" />
             <Button Clicked="GetActionPlans_OnClicked" Text="Get Action Plans" />
+            <Button Clicked="AuthorizeAdditionalRecords_OnClicked" Text="Authorize Additional Records" />
             <Button Clicked="Disconnect_OnClicked" Text="Disconnect" />
         </StackLayout>
         <Label x:Name="OutputLabel" />

--- a/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml.cs
+++ b/SandboxXamarinForms/SandboxXamarinForms/MainPage.xaml.cs
@@ -142,6 +142,11 @@ namespace SandboxXamarinForms
             OutputLabel.Text = $"There are {actionPlansResponse.Plans.Count} action plans";
         }
 
+        private async void AuthorizeAdditionalRecords_OnClicked(object sender, EventArgs e)
+        {
+            await _connection.AuthorizeAdditionalRecordsAsync();
+        }
+
         private async void Disconnect_OnClicked(object sender, EventArgs e)
         {
             await _connection.DeauthorizeApplicationAsync();


### PR DESCRIPTION
Two problems: one is that we were passing in the wrong target when creating the URL, and two we were passing in the master app ID when it was expecting the app instance ID.