### PR TITLE
HealthVault CertStore config

### DIFF
--- a/Microsoft.HealthVault.Web/Configuration/WebConfigurationReader.cs
+++ b/Microsoft.HealthVault.Web/Configuration/WebConfigurationReader.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Web;
 using System.Web.Configuration;
 using Microsoft.HealthVault.Configuration;
@@ -75,6 +76,7 @@ namespace Microsoft.HealthVault.Web.Configuration
                 AllowedRedirectSites = appSettings[ConfigKeys.AllowedRedirectSites],
                 ApplicationCertificateFileName = appSettings[ConfigKeys.ApplicationCertificateFileName],
                 ApplicationCertificatePassword = appSettings[ConfigKeys.ApplicationCertificatePassword],
+                CertStore = (StoreLocation)appSettings.GetTypedValue(ConfigKeys.CertStore, (int)ConfigDefaults.CertStore),
                 CertSubject = appSettings[ConfigKeys.CertSubject],
                 CookieDomain = appSettings[ConfigKeys.CookieDomain] ?? ConfigDefaults.CookieDomain,
                 CookieEncryptionKey = GetEncryptionKey(appSettings[ConfigKeys.CookieEncryptionKey]),

--- a/Microsoft.HealthVault.Web/Configuration/WebHealthVaultConfiguration.cs
+++ b/Microsoft.HealthVault.Web/Configuration/WebHealthVaultConfiguration.cs
@@ -8,6 +8,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Web;
 using Microsoft.HealthVault.Configuration;
 
 namespace Microsoft.HealthVault.Web.Configuration
@@ -61,6 +63,14 @@ namespace Microsoft.HealthVault.Web.Configuration
         /// This property corresponds to the "HV_ApplicationCertificatePassword" configuration value when reading from web.config.
         /// </remarks>
         public string ApplicationCertificatePassword { get; internal set; }
+
+        /// <summary>
+        /// Gets the Certificate Store to use
+        /// </summary>
+        /// <remarks>
+        /// This property corresponds to the "HV_AppCertStore" configuration value when reading from web.config
+        /// </remarks>
+        public StoreLocation CertStore { get; internal set; }
 
         /// <summary>
         /// Gets the Certificate Subject.

--- a/Microsoft.HealthVault.Web/Constants/HealthVaultWebConstants.cs
+++ b/Microsoft.HealthVault.Web/Constants/HealthVaultWebConstants.cs
@@ -7,6 +7,7 @@
 // THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.HealthVault.Web.Constants
 {
@@ -19,6 +20,7 @@ namespace Microsoft.HealthVault.Web.Constants
             internal const string AppId = "HV_ApplicationId";
             internal const string ApplicationCertificateFileName = "HV_ApplicationCertificateFilename";
             internal const string ApplicationCertificatePassword = "HV_ApplicationCertificatePassword";
+            internal const string CertStore = "HV_AppCertStore";
             internal const string CertSubject = "HV_AppCertSubject";
             internal const string CookieDomain = "HV_CookieDomain";
             internal const string CookieEncryptionKey = "HV_CookieEncryptionKey";
@@ -46,6 +48,7 @@ namespace Microsoft.HealthVault.Web.Constants
         {
             internal const string CookieNameSuffix = "_HV";
             internal const bool IsMra = false;
+            internal const StoreLocation CertStore = StoreLocation.LocalMachine;
             internal const string CookieDomain = "";
             internal const string CookiePath = "";
             internal static readonly TimeSpan CookieTimeoutDuration = TimeSpan.FromMinutes(20);

--- a/Microsoft.HealthVault.Web/Providers/CertificateInfoProvider.cs
+++ b/Microsoft.HealthVault.Web/Providers/CertificateInfoProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.HealthVault.Web.Providers
             _configuration = configuration;
             _applicationId = configuration.MasterApplicationId;
 
-            _storeLocation = StoreLocation.LocalMachine;
+            _storeLocation = configuration.CertStore;
             _certSubject = "CN=" + GetApplicationCertificateSubject();
 
             _x509Certificate2 = GetApplicationCertificate();


### PR DESCRIPTION
We should allow the Certificate Store to be specified via configuration.  Azure WebSites only allow reading from the CurrentUser store and not the LocalMachine store which the SDK is hardcoded to use.